### PR TITLE
Encode revision number as uint64

### DIFF
--- a/persist/sqlite/addresses.go
+++ b/persist/sqlite/addresses.go
@@ -50,7 +50,7 @@ func scanEvent(tx *txn, s scanner) (ev explorer.Event, eventID int64, err error)
 FROM contract_payout_events ev
 JOIN siacoin_elements sce ON ev.output_id = sce.id
 JOIN file_contract_elements fce ON ev.contract_id = fce.id
-WHERE ev.event_id = ?`, eventID).Scan(decode(&m.SiacoinOutput.StateElement.ID), decode(&m.SiacoinOutput.StateElement.LeafIndex), &m.SiacoinOutput.MaturityHeight, decode(&m.SiacoinOutput.SiacoinOutput.Address), decode(&m.SiacoinOutput.SiacoinOutput.Value), decode(&m.FileContract.StateElement.ID), decode(&m.FileContract.StateElement.LeafIndex), &m.FileContract.FileContract.Filesize, decode(&m.FileContract.FileContract.FileMerkleRoot), &m.FileContract.FileContract.WindowStart, &m.FileContract.FileContract.WindowEnd, decode(&m.FileContract.FileContract.Payout), decode(&m.FileContract.FileContract.UnlockHash), &m.FileContract.FileContract.RevisionNumber, &m.Missed)
+WHERE ev.event_id = ?`, eventID).Scan(decode(&m.SiacoinOutput.StateElement.ID), decode(&m.SiacoinOutput.StateElement.LeafIndex), &m.SiacoinOutput.MaturityHeight, decode(&m.SiacoinOutput.SiacoinOutput.Address), decode(&m.SiacoinOutput.SiacoinOutput.Value), decode(&m.FileContract.StateElement.ID), decode(&m.FileContract.StateElement.LeafIndex), &m.FileContract.FileContract.Filesize, decode(&m.FileContract.FileContract.FileMerkleRoot), &m.FileContract.FileContract.WindowStart, &m.FileContract.FileContract.WindowEnd, decode(&m.FileContract.FileContract.Payout), decode(&m.FileContract.FileContract.UnlockHash), decode(&m.FileContract.FileContract.RevisionNumber), &m.Missed)
 		ev.Data = &m
 	case explorer.EventTypeMinerPayout:
 		var m explorer.EventMinerPayout

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -698,7 +698,7 @@ func addFileContractElements(tx *txn, b types.Block, fces []explorer.FileContrac
 	fcDBIds := make(map[explorer.DBFileContract]int64)
 	addFC := func(fcID types.FileContractID, leafIndex uint64, fc types.FileContract, resolved, valid, lastRevision bool) error {
 		var dbID int64
-		err := stmt.QueryRow(encode(b.ID()), encode(fcID), encode(leafIndex), fc.Filesize, encode(fc.FileMerkleRoot), fc.WindowStart, fc.WindowEnd, encode(fc.Payout), encode(fc.UnlockHash), fc.RevisionNumber, resolved, valid, encode(leafIndex)).Scan(&dbID)
+		err := stmt.QueryRow(encode(b.ID()), encode(fcID), encode(leafIndex), fc.Filesize, encode(fc.FileMerkleRoot), fc.WindowStart, fc.WindowEnd, encode(fc.Payout), encode(fc.UnlockHash), encode(fc.RevisionNumber), resolved, valid, encode(leafIndex)).Scan(&dbID)
 		if err != nil {
 			return fmt.Errorf("failed to execute file_contract_elements statement: %w", err)
 		}

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -33,7 +33,7 @@ func (s *Store) Contracts(ids []types.FileContractID) (result []explorer.FileCon
 		for rows.Next() {
 			var contractID int64
 			var fc explorer.FileContract
-			if err := rows.Scan(&contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, &fc.Filesize, decode(&fc.FileMerkleRoot), &fc.WindowStart, &fc.WindowEnd, decode(&fc.Payout), decode(&fc.UnlockHash), &fc.RevisionNumber); err != nil {
+			if err := rows.Scan(&contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, &fc.Filesize, decode(&fc.FileMerkleRoot), &fc.WindowStart, &fc.WindowEnd, decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
 				return fmt.Errorf("failed to scan transaction: %w", err)
 			}
 

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -72,7 +72,7 @@ CREATE TABLE file_contract_elements (
         window_end INTEGER NOT NULL,
         payout BLOB NOT NULL,
         unlock_hash BLOB NOT NULL,
-        revision_number INTEGER NOT NULL,
+        revision_number BLOB NOT NULL,
         UNIQUE(contract_id, revision_number)
 );
 

--- a/persist/sqlite/transactions.go
+++ b/persist/sqlite/transactions.go
@@ -212,7 +212,7 @@ ORDER BY ts.transaction_order ASC`
 	for rows.Next() {
 		var txnID, contractID int64
 		var fc explorer.FileContract
-		if err := rows.Scan(&txnID, &contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, &fc.Filesize, decode(&fc.FileMerkleRoot), &fc.WindowStart, &fc.WindowEnd, decode(&fc.Payout), decode(&fc.UnlockHash), &fc.RevisionNumber); err != nil {
+		if err := rows.Scan(&txnID, &contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, &fc.Filesize, decode(&fc.FileMerkleRoot), &fc.WindowStart, &fc.WindowEnd, decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
 			return nil, fmt.Errorf("failed to scan file contract: %w", err)
 		}
 
@@ -255,7 +255,7 @@ ORDER BY ts.transaction_order ASC`
 	for rows.Next() {
 		var txnID, contractID int64
 		var fc explorer.FileContractRevision
-		if err := rows.Scan(&txnID, &contractID, decode(&fc.ParentID), decode(&fc.UnlockConditions), decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, &fc.Filesize, decode(&fc.FileMerkleRoot), &fc.WindowStart, &fc.WindowEnd, decode(&fc.Payout), decode(&fc.UnlockHash), &fc.RevisionNumber); err != nil {
+		if err := rows.Scan(&txnID, &contractID, decode(&fc.ParentID), decode(&fc.UnlockConditions), decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, &fc.Filesize, decode(&fc.FileMerkleRoot), &fc.WindowStart, &fc.WindowEnd, decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
 			return nil, fmt.Errorf("failed to scan file contract: %w", err)
 		}
 


### PR DESCRIPTION
Fix https://github.com/SiaFoundation/explored/issues/31 and store the revision number as encoded uint64 in the database instead of using SQLite INTEGER type which has a more limited range.