### PR TITLE
Close statements

### DIFF
--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -269,6 +269,7 @@ func addTransactions(tx *txn, bid types.BlockID, txns []types.Transaction, scDBI
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare check transaction statement: %v", err)
 	}
+	defer checkTransactionStmt.Close()
 
 	insertTransactionStmt, err := tx.Prepare(`INSERT INTO transactions (transaction_id) VALUES (?)`)
 	if err != nil {
@@ -747,6 +748,7 @@ func addFileContractElements(tx *txn, b types.Block, fces []explorer.FileContrac
 	if err != nil {
 		return nil, fmt.Errorf("addFileContractElements: failed to prepare last_contract_revision statement: %w", err)
 	}
+	defer revisionStmt.Close()
 
 	fcDBIds := make(map[explorer.DBFileContract]int64)
 	addFC := func(fcID types.FileContractID, leafIndex uint64, fc types.FileContract, resolved, valid, lastRevision bool) error {


### PR DESCRIPTION
Add two stmt.Close()s for statements that were not being closed

Edit: `sqlclosecheck` won't work because of our wrapping around database functions.  Custom linter could probably be made, but probably not worth it given that these are in general low stakes issues.