### PR TITLE
Add index to `maturity_height` in `siacoin_elements`

### DIFF
--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -53,6 +53,7 @@ CREATE TABLE siacoin_elements (
         value BLOB NOT NULL
 );
 
+CREATE INDEX siacoin_elements_maturity_height_index ON siacoin_elements(maturity_height);
 CREATE INDEX siacoin_elements_output_id_index ON siacoin_elements(output_id);
 CREATE INDEX siacoin_elements_address_spent_index ON siacoin_elements(address, spent);
 


### PR DESCRIPTION
Most of the debug logs warning about slow queries are about a particular query in updateMaturedBalances.

```
SELECT address, value FROM siacoin_elements WHERE maturity_height = ?
```

By adding an index on `siacoin_elements(maturity_height)` we can speed this up substantially.