### PR TITLE
Simplify FileContract types

### DIFF
--- a/explorer/types.go
+++ b/explorer/types.go
@@ -72,36 +72,20 @@ type SiacoinOutput struct {
 // A SiafundOutput is a types.SiafundElement.
 type SiafundOutput types.SiafundElement
 
-// A FileContract is a types.FileContractElement that uses wrapped types
-// internally.
+// A FileContract is a types.FileContractElement with added fields for
+// resolved/valid state.
 type FileContract struct {
-	types.StateElement
-
 	Resolved bool `json:"resolved"`
 	Valid    bool `json:"valid"`
-
-	Filesize           uint64                `json:"filesize"`
-	FileMerkleRoot     types.Hash256         `json:"fileMerkleRoot"`
-	WindowStart        uint64                `json:"windowStart"`
-	WindowEnd          uint64                `json:"windowEnd"`
-	Payout             types.Currency        `json:"payout"`
-	ValidProofOutputs  []types.SiacoinOutput `json:"validProofOutputs"`
-	MissedProofOutputs []types.SiacoinOutput `json:"missedProofOutputs"`
-	UnlockHash         types.Hash256         `json:"unlockHash"`
-	RevisionNumber     uint64                `json:"revisionNumber"`
+	types.FileContractElement
 }
 
-// A FileContractRevision is a types.FileContractRevision that uses wrapped
-// types internally.
+// A FileContractRevision is a FileContract with extra fields for revision
+// information.
 type FileContractRevision struct {
 	ParentID         types.FileContractID   `json:"parentID"`
 	UnlockConditions types.UnlockConditions `json:"unlockConditions"`
-	// NOTE: the Payout field of the contract is not "really" part of a
-	// revision. A revision cannot change the total payout, so the original siad
-	// code defines FileContractRevision as an entirely separate struct without
-	// a Payout field. Here, we instead reuse the FileContract type, which means
-	// we must treat its Payout field as invalid. To guard against developer
-	// error, we set it to a sentinel value when decoding it.
+
 	FileContract
 }
 

--- a/persist/sqlite/consensus_test.go
+++ b/persist/sqlite/consensus_test.go
@@ -782,22 +782,24 @@ func TestFileContract(t *testing.T) {
 	checkFC := func(resolved, valid bool, expected types.FileContract, got explorer.FileContract) {
 		check(t, "resolved state", resolved, got.Resolved)
 		check(t, "valid state", valid, got.Valid)
-		check(t, "filesize", expected.Filesize, got.Filesize)
-		check(t, "file merkle root", expected.FileMerkleRoot, got.FileMerkleRoot)
-		check(t, "window start", expected.WindowStart, got.WindowStart)
-		check(t, "window end", expected.WindowEnd, got.WindowEnd)
-		check(t, "payout", expected.Payout, got.Payout)
-		check(t, "unlock hash", expected.UnlockHash, got.UnlockHash)
-		check(t, "revision number", expected.RevisionNumber, got.RevisionNumber)
-		check(t, "valid proof outputs", len(expected.ValidProofOutputs), len(got.ValidProofOutputs))
+
+		gotFC := got.FileContract
+		check(t, "filesize", expected.Filesize, gotFC.Filesize)
+		check(t, "file merkle root", expected.FileMerkleRoot, gotFC.FileMerkleRoot)
+		check(t, "window start", expected.WindowStart, gotFC.WindowStart)
+		check(t, "window end", expected.WindowEnd, gotFC.WindowEnd)
+		check(t, "payout", expected.Payout, gotFC.Payout)
+		check(t, "unlock hash", expected.UnlockHash, gotFC.UnlockHash)
+		check(t, "revision number", expected.RevisionNumber, gotFC.RevisionNumber)
+		check(t, "valid proof outputs", len(expected.ValidProofOutputs), len(gotFC.ValidProofOutputs))
 		for i := range expected.ValidProofOutputs {
-			check(t, "valid proof output address", expected.ValidProofOutputs[i].Address, got.ValidProofOutputs[i].Address)
-			check(t, "valid proof output value", expected.ValidProofOutputs[i].Value, got.ValidProofOutputs[i].Value)
+			check(t, "valid proof output address", expected.ValidProofOutputs[i].Address, gotFC.ValidProofOutputs[i].Address)
+			check(t, "valid proof output value", expected.ValidProofOutputs[i].Value, gotFC.ValidProofOutputs[i].Value)
 		}
-		check(t, "missed proof outputs", len(expected.MissedProofOutputs), len(got.MissedProofOutputs))
+		check(t, "missed proof outputs", len(expected.MissedProofOutputs), len(gotFC.MissedProofOutputs))
 		for i := range expected.MissedProofOutputs {
-			check(t, "missed proof output address", expected.MissedProofOutputs[i].Address, got.MissedProofOutputs[i].Address)
-			check(t, "missed proof output value", expected.MissedProofOutputs[i].Value, got.MissedProofOutputs[i].Value)
+			check(t, "missed proof output address", expected.MissedProofOutputs[i].Address, gotFC.MissedProofOutputs[i].Address)
+			check(t, "missed proof output value", expected.MissedProofOutputs[i].Value, gotFC.MissedProofOutputs[i].Value)
 		}
 	}
 
@@ -1033,30 +1035,32 @@ func TestEphemeralFileContract(t *testing.T) {
 	checkFC := func(revision, resolved, valid bool, expected types.FileContract, got explorer.FileContract) {
 		check(t, "resolved state", resolved, got.Resolved)
 		check(t, "valid state", valid, got.Valid)
-		check(t, "filesize", expected.Filesize, got.Filesize)
-		check(t, "file merkle root", expected.FileMerkleRoot, got.FileMerkleRoot)
-		check(t, "window start", expected.WindowStart, got.WindowStart)
-		check(t, "window end", expected.WindowEnd, got.WindowEnd)
+
+		gotFC := got.FileContract
+		check(t, "filesize", expected.Filesize, gotFC.Filesize)
+		check(t, "file merkle root", expected.FileMerkleRoot, gotFC.FileMerkleRoot)
+		check(t, "window start", expected.WindowStart, gotFC.WindowStart)
+		check(t, "window end", expected.WindowEnd, gotFC.WindowEnd)
 
 		// See core/types.FileContractRevision
 		// Essentially, a revision cannot change the total payout, so this value
 		// is replaced with a sentinel value of types.MaxCurrency in revisions
 		// if it is decoded.
 		if !revision {
-			check(t, "payout", expected.Payout, got.Payout)
+			check(t, "payout", expected.Payout, gotFC.Payout)
 		}
 
-		check(t, "unlock hash", expected.UnlockHash, got.UnlockHash)
-		check(t, "revision number", expected.RevisionNumber, got.RevisionNumber)
-		check(t, "valid proof outputs", len(expected.ValidProofOutputs), len(got.ValidProofOutputs))
+		check(t, "unlock hash", expected.UnlockHash, gotFC.UnlockHash)
+		check(t, "revision number", expected.RevisionNumber, gotFC.RevisionNumber)
+		check(t, "valid proof outputs", len(expected.ValidProofOutputs), len(gotFC.ValidProofOutputs))
 		for i := range expected.ValidProofOutputs {
-			check(t, "valid proof output address", expected.ValidProofOutputs[i].Address, got.ValidProofOutputs[i].Address)
-			check(t, "valid proof output value", expected.ValidProofOutputs[i].Value, got.ValidProofOutputs[i].Value)
+			check(t, "valid proof output address", expected.ValidProofOutputs[i].Address, gotFC.ValidProofOutputs[i].Address)
+			check(t, "valid proof output value", expected.ValidProofOutputs[i].Value, gotFC.ValidProofOutputs[i].Value)
 		}
-		check(t, "missed proof outputs", len(expected.MissedProofOutputs), len(got.MissedProofOutputs))
+		check(t, "missed proof outputs", len(expected.MissedProofOutputs), len(gotFC.MissedProofOutputs))
 		for i := range expected.MissedProofOutputs {
-			check(t, "missed proof output address", expected.MissedProofOutputs[i].Address, got.MissedProofOutputs[i].Address)
-			check(t, "missed proof output value", expected.MissedProofOutputs[i].Value, got.MissedProofOutputs[i].Value)
+			check(t, "missed proof output address", expected.MissedProofOutputs[i].Address, gotFC.MissedProofOutputs[i].Address)
+			check(t, "missed proof output value", expected.MissedProofOutputs[i].Value, gotFC.MissedProofOutputs[i].Value)
 		}
 	}
 
@@ -2402,22 +2406,24 @@ func TestMultipleReorgFileContract(t *testing.T) {
 	checkFC := func(resolved, valid bool, expected types.FileContract, got explorer.FileContract) {
 		check(t, "resolved state", resolved, got.Resolved)
 		check(t, "valid state", valid, got.Valid)
-		check(t, "filesize", expected.Filesize, got.Filesize)
-		check(t, "file merkle root", expected.FileMerkleRoot, got.FileMerkleRoot)
-		check(t, "window start", expected.WindowStart, got.WindowStart)
-		check(t, "window end", expected.WindowEnd, got.WindowEnd)
-		check(t, "payout", expected.Payout, got.Payout)
-		check(t, "unlock hash", expected.UnlockHash, got.UnlockHash)
-		check(t, "revision number", expected.RevisionNumber, got.RevisionNumber)
-		check(t, "valid proof outputs", len(expected.ValidProofOutputs), len(got.ValidProofOutputs))
+
+		gotFC := got.FileContract
+		check(t, "filesize", expected.Filesize, gotFC.Filesize)
+		check(t, "file merkle root", expected.FileMerkleRoot, gotFC.FileMerkleRoot)
+		check(t, "window start", expected.WindowStart, gotFC.WindowStart)
+		check(t, "window end", expected.WindowEnd, gotFC.WindowEnd)
+		check(t, "payout", expected.Payout, gotFC.Payout)
+		check(t, "unlock hash", expected.UnlockHash, gotFC.UnlockHash)
+		check(t, "revision number", expected.RevisionNumber, gotFC.RevisionNumber)
+		check(t, "valid proof outputs", len(expected.ValidProofOutputs), len(gotFC.ValidProofOutputs))
 		for i := range expected.ValidProofOutputs {
-			check(t, "valid proof output address", expected.ValidProofOutputs[i].Address, got.ValidProofOutputs[i].Address)
-			check(t, "valid proof output value", expected.ValidProofOutputs[i].Value, got.ValidProofOutputs[i].Value)
+			check(t, "valid proof output address", expected.ValidProofOutputs[i].Address, gotFC.ValidProofOutputs[i].Address)
+			check(t, "valid proof output value", expected.ValidProofOutputs[i].Value, gotFC.ValidProofOutputs[i].Value)
 		}
-		check(t, "missed proof outputs", len(expected.MissedProofOutputs), len(got.MissedProofOutputs))
+		check(t, "missed proof outputs", len(expected.MissedProofOutputs), len(gotFC.MissedProofOutputs))
 		for i := range expected.MissedProofOutputs {
-			check(t, "missed proof output address", expected.MissedProofOutputs[i].Address, got.MissedProofOutputs[i].Address)
-			check(t, "missed proof output value", expected.MissedProofOutputs[i].Value, got.MissedProofOutputs[i].Value)
+			check(t, "missed proof output address", expected.MissedProofOutputs[i].Address, gotFC.MissedProofOutputs[i].Address)
+			check(t, "missed proof output value", expected.MissedProofOutputs[i].Value, gotFC.MissedProofOutputs[i].Value)
 		}
 	}
 

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -33,7 +33,7 @@ func (s *Store) Contracts(ids []types.FileContractID) (result []explorer.FileCon
 		for rows.Next() {
 			var contractID int64
 			var fc explorer.FileContract
-			if err := rows.Scan(&contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
+			if err := rows.Scan(&contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, decode(&fc.FileContract.Filesize), decode(&fc.FileContract.FileMerkleRoot), decode(&fc.FileContract.WindowStart), decode(&fc.FileContract.WindowEnd), decode(&fc.FileContract.Payout), decode(&fc.FileContract.UnlockHash), decode(&fc.FileContract.RevisionNumber)); err != nil {
 				return fmt.Errorf("failed to scan transaction: %w", err)
 			}
 
@@ -47,8 +47,8 @@ func (s *Store) Contracts(ids []types.FileContractID) (result []explorer.FileCon
 		}
 		for contractID, output := range proofOutputs {
 			fc := idContract[contractID]
-			fc.ValidProofOutputs = output.valid
-			fc.MissedProofOutputs = output.missed
+			fc.FileContract.ValidProofOutputs = output.valid
+			fc.FileContract.MissedProofOutputs = output.missed
 			result = append(result, fc)
 		}
 
@@ -76,7 +76,7 @@ func (s *Store) ContractsKey(key types.PublicKey) (result []explorer.FileContrac
 		for rows.Next() {
 			var contractID int64
 			var fc explorer.FileContract
-			if err := rows.Scan(&contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
+			if err := rows.Scan(&contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, decode(&fc.FileContract.Filesize), decode(&fc.FileContract.FileMerkleRoot), decode(&fc.FileContract.WindowStart), decode(&fc.FileContract.WindowEnd), decode(&fc.FileContract.Payout), decode(&fc.FileContract.UnlockHash), decode(&fc.FileContract.RevisionNumber)); err != nil {
 				return fmt.Errorf("failed to scan transaction: %w", err)
 			}
 
@@ -90,8 +90,8 @@ func (s *Store) ContractsKey(key types.PublicKey) (result []explorer.FileContrac
 		}
 		for contractID, output := range proofOutputs {
 			fc := idContract[contractID]
-			fc.ValidProofOutputs = output.valid
-			fc.MissedProofOutputs = output.missed
+			fc.FileContract.ValidProofOutputs = output.valid
+			fc.FileContract.MissedProofOutputs = output.missed
 			result = append(result, fc)
 		}
 

--- a/persist/sqlite/transactions.go
+++ b/persist/sqlite/transactions.go
@@ -260,7 +260,7 @@ ORDER BY ts.transaction_order ASC`
 	for rows.Next() {
 		var txnID, contractID int64
 		var fc explorer.FileContract
-		if err := rows.Scan(&txnID, &contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
+		if err := rows.Scan(&txnID, &contractID, decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, decode(&fc.FileContract.Filesize), decode(&fc.FileContract.FileMerkleRoot), decode(&fc.FileContract.WindowStart), decode(&fc.FileContract.WindowEnd), decode(&fc.FileContract.Payout), decode(&fc.FileContract.UnlockHash), decode(&fc.FileContract.RevisionNumber)); err != nil {
 			return nil, fmt.Errorf("failed to scan file contract: %w", err)
 		}
 
@@ -275,8 +275,8 @@ ORDER BY ts.transaction_order ASC`
 	}
 	for contractID, output := range proofOutputs {
 		index := contractTransaction[contractID]
-		result[index.txnID][index.transactionOrder].ValidProofOutputs = output.valid
-		result[index.txnID][index.transactionOrder].MissedProofOutputs = output.missed
+		result[index.txnID][index.transactionOrder].FileContract.ValidProofOutputs = output.valid
+		result[index.txnID][index.transactionOrder].FileContract.MissedProofOutputs = output.missed
 	}
 
 	return result, nil
@@ -303,7 +303,7 @@ ORDER BY ts.transaction_order ASC`
 	for rows.Next() {
 		var txnID, contractID int64
 		var fc explorer.FileContractRevision
-		if err := rows.Scan(&txnID, &contractID, decode(&fc.ParentID), decode(&fc.UnlockConditions), decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
+		if err := rows.Scan(&txnID, &contractID, decode(&fc.ParentID), decode(&fc.UnlockConditions), decode(&fc.StateElement.ID), decode(&fc.StateElement.LeafIndex), &fc.Resolved, &fc.Valid, decode(&fc.FileContract.FileContract.Filesize), decode(&fc.FileContract.FileContract.FileMerkleRoot), decode(&fc.FileContract.FileContract.WindowStart), decode(&fc.FileContract.FileContract.WindowEnd), decode(&fc.FileContract.FileContract.Payout), decode(&fc.FileContract.FileContract.UnlockHash), decode(&fc.FileContract.FileContract.RevisionNumber)); err != nil {
 			return nil, fmt.Errorf("failed to scan file contract: %w", err)
 		}
 
@@ -318,8 +318,8 @@ ORDER BY ts.transaction_order ASC`
 	}
 	for contractID, output := range proofOutputs {
 		index := contractTransaction[contractID]
-		result[index.txnID][index.transactionOrder].ValidProofOutputs = output.valid
-		result[index.txnID][index.transactionOrder].MissedProofOutputs = output.missed
+		result[index.txnID][index.transactionOrder].FileContract.FileContract.ValidProofOutputs = output.valid
+		result[index.txnID][index.transactionOrder].FileContract.FileContract.MissedProofOutputs = output.missed
 	}
 
 	return result, nil


### PR DESCRIPTION
Just use a `types.FileContractElement` instead of redefining fields from `types.FileContract`.