### PR TITLE
Change ContractRevisions return type for consistency

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -186,7 +186,7 @@ func (c *Client) ContractsKey(key types.PublicKey) (resp []explorer.FileContract
 
 // ContractRevisions returns all the revisions of the contract with the
 // specified ID.
-func (c *Client) ContractRevisions(id types.FileContractID) (resp []types.FileContractElement, err error) {
+func (c *Client) ContractRevisions(id types.FileContractID) (resp []explorer.FileContract, err error) {
 	err = c.c.GET(fmt.Sprintf("/contracts/%s/revisions", id), &resp)
 	return
 }

--- a/api/server.go
+++ b/api/server.go
@@ -62,7 +62,7 @@ type (
 		AddressEvents(address types.Address, offset, limit uint64) (events []explorer.Event, err error)
 		Contracts(ids []types.FileContractID) (result []explorer.FileContract, err error)
 		ContractsKey(key types.PublicKey) (result []explorer.FileContract, err error)
-		ContractRevisions(id types.FileContractID) (result []types.FileContractElement, err error)
+		ContractRevisions(id types.FileContractID) (result []explorer.FileContract, err error)
 		Search(id types.Hash256) (explorer.SearchType, error)
 
 		Hosts(pks []types.PublicKey) ([]explorer.Host, error)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -56,7 +56,7 @@ type Store interface {
 	Balance(address types.Address) (sc types.Currency, immatureSC types.Currency, sf uint64, err error)
 	Contracts(ids []types.FileContractID) (result []FileContract, err error)
 	ContractsKey(key types.PublicKey) (result []FileContract, err error)
-	ContractRevisions(id types.FileContractID) (result []types.FileContractElement, err error)
+	ContractRevisions(id types.FileContractID) (result []FileContract, err error)
 	SiacoinElements(ids []types.SiacoinOutputID) (result []SiacoinOutput, err error)
 	SiafundElements(ids []types.SiafundOutputID) (result []SiafundOutput, err error)
 
@@ -243,7 +243,7 @@ func (e *Explorer) ContractsKey(key types.PublicKey) (result []FileContract, err
 
 // ContractRevisions returns all the revisions of the contract with the
 // specified ID.
-func (e *Explorer) ContractRevisions(id types.FileContractID) (result []types.FileContractElement, err error) {
+func (e *Explorer) ContractRevisions(id types.FileContractID) (result []FileContract, err error) {
 	return e.s.ContractRevisions(id)
 }
 

--- a/persist/sqlite/consensus_test.go
+++ b/persist/sqlite/consensus_test.go
@@ -139,7 +139,7 @@ func checkMetrics(t *testing.T, db explorer.Store, cm *chain.Manager, expected e
 	// don't check circulating supply here because it requires a lot of accounting
 }
 
-func checkFCRevisions(t *testing.T, revisionNumbers []uint64, fcs []types.FileContractElement) {
+func checkFCRevisions(t *testing.T, revisionNumbers []uint64, fcs []explorer.FileContract) {
 	t.Helper()
 
 	check(t, "number of revisions", len(revisionNumbers), len(fcs))


### PR DESCRIPTION
All of the other contract functions return explorer.FileContracts so it is easier for API consumers if we use those instead in ContractRevisions, even though we will be returning redundant data for ProofIndex, ConfirmationIndex, etc.