### PR TITLE
Make contract confirmation index NOT NULL

### DIFF
--- a/explorer/types.go
+++ b/explorer/types.go
@@ -139,8 +139,8 @@ type ExtendedFileContract struct {
 
 	TransactionID types.TransactionID `json:"transactionID"`
 
-	ConfirmationIndex         *types.ChainIndex    `json:"confirmationIndex"`
-	ConfirmationTransactionID *types.TransactionID `json:"confirmationTransactionID"`
+	ConfirmationIndex         types.ChainIndex    `json:"confirmationIndex"`
+	ConfirmationTransactionID types.TransactionID `json:"confirmationTransactionID"`
 
 	ProofIndex         *types.ChainIndex    `json:"proofIndex"`
 	ProofTransactionID *types.TransactionID `json:"proofTransactionID"`
@@ -188,8 +188,8 @@ type Transaction struct {
 type V2FileContract struct {
 	TransactionID types.TransactionID `json:"transactionID"`
 
-	ConfirmationIndex         *types.ChainIndex    `json:"confirmationIndex"`
-	ConfirmationTransactionID *types.TransactionID `json:"confirmationTransactionID"`
+	ConfirmationIndex         types.ChainIndex    `json:"confirmationIndex"`
+	ConfirmationTransactionID types.TransactionID `json:"confirmationTransactionID"`
 
 	ResolutionIndex         *types.ChainIndex    `json:"resolutionIndex"`
 	ResolutionTransactionID *types.TransactionID `json:"resolutionTransactionID"`

--- a/explorer/update.go
+++ b/explorer/update.go
@@ -180,7 +180,7 @@ func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate) error {
 	for _, txn := range cau.Block.V2Transactions() {
 		txnID := txn.ID()
 		for i := range txn.FileContracts {
-			fcID := txn.V2FileContractID(txn.ID(), i)
+			fcID := txn.V2FileContractID(txnID, i)
 
 			v := v2FceMap[fcID]
 			v.ConfirmationTransactionID = &txnID
@@ -192,6 +192,13 @@ func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate) error {
 			v := v2FceMap[fcID]
 			v.ResolutionTransactionID = &txnID
 			v2FceMap[fcID] = v
+
+			if _, ok := fcr.Resolution.(*types.V2FileContractRenewal); ok {
+				renewalID := fcID.V2RenewalID()
+				v := v2FceMap[renewalID]
+				v.ConfirmationTransactionID = &txnID
+				v2FceMap[renewalID] = v
+			}
 		}
 	}
 

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -747,7 +747,7 @@ func deleteBlock(tx *txn, bid types.BlockID) error {
 	return err
 }
 
-func updateFileContractElements(tx *txn, revert bool, b types.Block, fces []explorer.FileContractUpdate) (map[explorer.DBFileContract]int64, error) {
+func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b types.Block, fces []explorer.FileContractUpdate) (map[explorer.DBFileContract]int64, error) {
 	stmt, err := tx.Prepare(`INSERT INTO file_contract_elements(contract_id, block_id, transaction_id, leaf_index, resolved, valid, filesize, file_merkle_root, window_start, window_end, payout, unlock_hash, revision_number)
 		VALUES (?, ?, ?, ?, FALSE, FALSE, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT (contract_id, revision_number)
@@ -758,10 +758,10 @@ func updateFileContractElements(tx *txn, revert bool, b types.Block, fces []expl
 	}
 	defer stmt.Close()
 
-	revisionStmt, err := tx.Prepare(`INSERT INTO last_contract_revision(contract_id, contract_element_id, ed25519_renter_key, ed25519_host_key)
-	VALUES (?, ?, ?, ?)
+	revisionStmt, err := tx.Prepare(`INSERT INTO last_contract_revision(contract_id, contract_element_id, ed25519_renter_key, ed25519_host_key, confirmation_index, confirmation_transaction_id)
+	VALUES (?, ?, ?, ?, COALESCE(?, X'aa'), COALESCE(?, X'aa'))
 	ON CONFLICT (contract_id)
-	DO UPDATE SET contract_element_id = ?, ed25519_renter_key = COALESCE(?, ed25519_renter_key), ed25519_host_key = COALESCE(?, ed25519_host_key)`)
+	DO UPDATE SET contract_element_id = ?, ed25519_renter_key = COALESCE(?, ed25519_renter_key), ed25519_host_key = COALESCE(?, ed25519_host_key), confirmation_index = COALESCE(?, confirmation_index), confirmation_transaction_id = COALESCE(?, confirmation_transaction_id)`)
 	if err != nil {
 		return nil, fmt.Errorf("updateFileContractElements: failed to prepare last_contract_revision statement: %w", err)
 	}
@@ -829,10 +829,10 @@ func updateFileContractElements(tx *txn, revert bool, b types.Block, fces []expl
 	}
 
 	fcDBIds := make(map[explorer.DBFileContract]int64)
-	addFC := func(fcID types.FileContractID, leafIndex uint64, fc types.FileContract, resolved, valid, lastRevision bool) error {
+	addFC := func(fcID types.FileContractID, leafIndex uint64, fc types.FileContract, confirmationTransactionID *types.TransactionID, resolved, valid, lastRevision bool) error {
 		var dbID int64
 		dbFC := explorer.DBFileContract{ID: fcID, RevisionNumber: fc.RevisionNumber}
-		err := stmt.QueryRow(encode(fcID), encode(b.ID()), encode(fcTxns[dbFC]), encode(leafIndex), encode(fc.Filesize), encode(fc.FileMerkleRoot), encode(fc.WindowStart), encode(fc.WindowEnd), encode(fc.Payout), encode(fc.UnlockHash), encode(fc.RevisionNumber), resolved, valid, encode(leafIndex)).Scan(&dbID)
+		err := stmt.QueryRow(encode(fcID), encode(index.ID), encode(fcTxns[dbFC]), encode(leafIndex), encode(fc.Filesize), encode(fc.FileMerkleRoot), encode(fc.WindowStart), encode(fc.WindowEnd), encode(fc.Payout), encode(fc.UnlockHash), encode(fc.RevisionNumber), resolved, valid, encode(leafIndex)).Scan(&dbID)
 		if err != nil {
 			return fmt.Errorf("failed to execute file_contract_elements statement: %w", err)
 		}
@@ -851,13 +851,20 @@ func updateFileContractElements(tx *txn, revert bool, b types.Block, fces []expl
 		// only update if it's the most recent revision which will come from
 		// running ForEachFileContractElement on the update
 		if lastRevision {
-			var renterKey, hostKey []byte
+			var encodedRenterKey, encodedHostKey []byte
 			if keys, ok := fcKeys[dbFC]; ok {
-				renterKey = encode(keys[0]).([]byte)
-				hostKey = encode(keys[1]).([]byte)
+				encodedRenterKey = encode(keys[0]).([]byte)
+				encodedHostKey = encode(keys[1]).([]byte)
 			}
 
-			if _, err := revisionStmt.Exec(encode(fcID), dbID, renterKey, hostKey, dbID, renterKey, hostKey); err != nil {
+			var encodedChainIndex []byte
+			var encodedConfirmationTransactionID []byte
+			if confirmationTransactionID != nil {
+				encodedChainIndex = encode(index).([]byte)
+				encodedConfirmationTransactionID = encode(*confirmationTransactionID).([]byte)
+			}
+
+			if _, err := revisionStmt.Exec(encode(fcID), dbID, encodedRenterKey, encodedHostKey, encodedChainIndex, encodedConfirmationTransactionID, dbID, encodedRenterKey, encodedHostKey, encodedChainIndex, encodedConfirmationTransactionID); err != nil {
 				return fmt.Errorf("failed to update last revision number: %w", err)
 			}
 		}
@@ -897,6 +904,7 @@ func updateFileContractElements(tx *txn, revert bool, b types.Block, fces []expl
 			fce.ID,
 			fce.StateElement.LeafIndex,
 			fce.FileContract,
+			update.ConfirmationTransactionID,
 			update.Resolved,
 			update.Valid,
 			true,
@@ -919,7 +927,7 @@ func updateFileContractElements(tx *txn, revert bool, b types.Block, fces []expl
 				continue
 			}
 
-			if err := addFC(fcID, 0, fc, false, false, false); err != nil {
+			if err := addFC(fcID, 0, fc, nil, false, false, false); err != nil {
 				return nil, fmt.Errorf("updateFileContractElements: %w", err)
 			}
 		}
@@ -932,7 +940,7 @@ func updateFileContractElements(tx *txn, revert bool, b types.Block, fces []expl
 				continue
 			}
 
-			if err := addFC(fcr.ParentID, 0, fc, false, false, false); err != nil {
+			if err := addFC(fcr.ParentID, 0, fc, nil, false, false, false); err != nil {
 				return nil, fmt.Errorf("updateFileContractElements: %w", err)
 			}
 		}
@@ -942,12 +950,6 @@ func updateFileContractElements(tx *txn, revert bool, b types.Block, fces []expl
 }
 
 func updateFileContractIndices(tx *txn, revert bool, index types.ChainIndex, fces []explorer.FileContractUpdate) error {
-	confirmationIndexStmt, err := tx.Prepare(`UPDATE last_contract_revision SET confirmation_index = ?, confirmation_transaction_id = ? WHERE contract_id = ?`)
-	if err != nil {
-		return fmt.Errorf("updateFileContractIndices: failed to prepare confirmation index statement: %w", err)
-	}
-	defer confirmationIndexStmt.Close()
-
 	proofIndexStmt, err := tx.Prepare(`UPDATE last_contract_revision SET proof_index = ?, proof_transaction_id = ? WHERE contract_id = ?`)
 	if err != nil {
 		return fmt.Errorf("updateFileContractIndices: failed to prepare proof index statement: %w", err)
@@ -959,22 +961,12 @@ func updateFileContractIndices(tx *txn, revert bool, index types.ChainIndex, fce
 		fcID := update.FileContractElement.ID
 
 		if revert {
-			if update.ConfirmationTransactionID != nil {
-				if _, err := confirmationIndexStmt.Exec(nil, nil, encode(fcID)); err != nil {
-					return fmt.Errorf("updateFileContractIndices: failed to update confirmation index: %w", err)
-				}
-			}
 			if update.ProofTransactionID != nil {
 				if _, err := proofIndexStmt.Exec(nil, nil, encode(fcID)); err != nil {
 					return fmt.Errorf("updateFileContractIndices: failed to update proof index: %w", err)
 				}
 			}
 		} else {
-			if update.ConfirmationTransactionID != nil {
-				if _, err := confirmationIndexStmt.Exec(encode(index), encode(update.ConfirmationTransactionID), encode(fcID)); err != nil {
-					return fmt.Errorf("updateFileContractIndices: failed to update confirmation index: %w", err)
-				}
-			}
 			if update.ProofTransactionID != nil {
 				if _, err := proofIndexStmt.Exec(encode(index), encode(update.ProofTransactionID), encode(fcID)); err != nil {
 					return fmt.Errorf("updateFileContractIndices: failed to update proof index: %w", err)
@@ -1052,12 +1044,12 @@ func (ut *updateTx) ApplyIndex(state explorer.UpdateState) error {
 	if err != nil {
 		return fmt.Errorf("ApplyIndex: failed to add siafund outputs: %w", err)
 	}
-	fcDBIds, err := updateFileContractElements(ut.tx, false, state.Block, state.FileContractElements)
+	fcDBIds, err := updateFileContractElements(ut.tx, false, state.Metrics.Index, state.Block, state.FileContractElements)
 	if err != nil {
 		return fmt.Errorf("ApplyIndex: failed to add file contracts: %w", err)
 	}
 
-	v2FcDBIds, err := updateV2FileContractElements(ut.tx, false, state.Block, state.V2FileContractElements)
+	v2FcDBIds, err := updateV2FileContractElements(ut.tx, false, state.Metrics.Index, state.Block, state.V2FileContractElements)
 	if err != nil {
 		return fmt.Errorf("ApplyIndex: failed to add v2 file contracts: %w", err)
 	}
@@ -1104,9 +1096,9 @@ func (ut *updateTx) RevertIndex(state explorer.UpdateState) error {
 		return fmt.Errorf("RevertIndex: failed to update siafund output state: %w", err)
 	} else if err := updateBalances(ut.tx, state.Metrics.Index.Height, state.SpentSiacoinElements, state.NewSiacoinElements, state.SpentSiafundElements, state.NewSiafundElements); err != nil {
 		return fmt.Errorf("RevertIndex: failed to update balances: %w", err)
-	} else if _, err := updateFileContractElements(ut.tx, true, state.Block, state.FileContractElements); err != nil {
+	} else if _, err := updateFileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.FileContractElements); err != nil {
 		return fmt.Errorf("RevertIndex: failed to update file contract state: %w", err)
-	} else if _, err := updateV2FileContractElements(ut.tx, true, state.Block, state.V2FileContractElements); err != nil {
+	} else if _, err := updateV2FileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.V2FileContractElements); err != nil {
 		return fmt.Errorf("ApplyIndex: failed to add v2 file contracts: %w", err)
 	} else if err := deleteBlock(ut.tx, state.Block.ID()); err != nil {
 		return fmt.Errorf("RevertIndex: failed to delete block: %w", err)

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -16,16 +16,10 @@ func encodedIDs(ids []types.FileContractID) []any {
 }
 
 func scanFileContract(s scanner) (contractID int64, fc explorer.ExtendedFileContract, err error) {
-	var confirmationIndex, proofIndex types.ChainIndex
-	var confirmationTransactionID, proofTransactionID types.TransactionID
-	err = s.Scan(&contractID, decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decodeNull(&confirmationIndex), decodeNull(&confirmationTransactionID), decodeNull(&proofIndex), decodeNull(&proofTransactionID), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber))
+	var proofIndex types.ChainIndex
+	var proofTransactionID types.TransactionID
+	err = s.Scan(&contractID, decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.ConfirmationIndex), decode(&fc.ConfirmationTransactionID), decodeNull(&proofIndex), decodeNull(&proofTransactionID), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber))
 
-	if confirmationIndex != (types.ChainIndex{}) {
-		fc.ConfirmationIndex = &confirmationIndex
-	}
-	if confirmationTransactionID != (types.TransactionID{}) {
-		fc.ConfirmationTransactionID = &confirmationTransactionID
-	}
 	if proofIndex != (types.ChainIndex{}) {
 		fc.ProofIndex = &proofIndex
 	}

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -18,7 +18,7 @@ func encodedIDs(ids []types.FileContractID) []any {
 func scanFileContract(s scanner) (contractID int64, fc explorer.ExtendedFileContract, err error) {
 	var proofIndex types.ChainIndex
 	var proofTransactionID types.TransactionID
-	err = s.Scan(&contractID, decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.ConfirmationIndex), decode(&fc.ConfirmationTransactionID), decodeNull(&proofIndex), decodeNull(&proofTransactionID), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber))
+	err = s.Scan(&contractID, decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.ConfirmationIndex.Height), decode(&fc.ConfirmationIndex.ID), decode(&fc.ConfirmationTransactionID), decodeNull(&proofIndex.Height), decodeNull(&proofIndex.ID), decodeNull(&proofTransactionID), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber))
 
 	if proofIndex != (types.ChainIndex{}) {
 		fc.ProofIndex = &proofIndex
@@ -33,7 +33,7 @@ func scanFileContract(s scanner) (contractID int64, fc explorer.ExtendedFileCont
 // Contracts implements explorer.Store.
 func (s *Store) Contracts(ids []types.FileContractID) (result []explorer.ExtendedFileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		query := `SELECT fc1.id, fc1.contract_id, fc1.resolved, fc1.valid, fc1.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.proof_index, rev.proof_transaction_id, fc1.filesize, fc1.file_merkle_root, fc1.window_start, fc1.window_end, fc1.payout, fc1.unlock_hash, fc1.revision_number
+		query := `SELECT fc1.id, fc1.contract_id, fc1.resolved, fc1.valid, fc1.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc1.filesize, fc1.file_merkle_root, fc1.window_start, fc1.window_end, fc1.payout, fc1.unlock_hash, fc1.revision_number
 			FROM file_contract_elements fc1
 			INNER JOIN last_contract_revision rev ON rev.contract_element_id = fc1.id
 			WHERE rev.contract_id IN (` + queryPlaceHolders(len(ids)) + `)`
@@ -78,7 +78,7 @@ func (s *Store) Contracts(ids []types.FileContractID) (result []explorer.Extende
 // ContractRevisions implements explorer.Store.
 func (s *Store) ContractRevisions(id types.FileContractID) (revisions []explorer.ExtendedFileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		query := `SELECT fc.id, fc.contract_id, fc.resolved, fc.valid, fc.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.proof_index, rev.proof_transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
+		query := `SELECT fc.id, fc.contract_id, fc.resolved, fc.valid, fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
 			FROM file_contract_elements fc
 			JOIN last_contract_revision rev ON rev.contract_id = fc.contract_id
 			WHERE fc.contract_id = ?
@@ -136,7 +136,7 @@ func (s *Store) ContractRevisions(id types.FileContractID) (revisions []explorer
 // ContractsKey implements explorer.Store.
 func (s *Store) ContractsKey(key types.PublicKey) (result []explorer.ExtendedFileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		query := `SELECT fc1.id, fc1.contract_id, fc1.resolved, fc1.valid, fc1.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.proof_index, rev.proof_transaction_id, fc1.filesize, fc1.file_merkle_root, fc1.window_start, fc1.window_end, fc1.payout, fc1.unlock_hash, fc1.revision_number
+		query := `SELECT fc1.id, fc1.contract_id, fc1.resolved, fc1.valid, fc1.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc1.filesize, fc1.file_merkle_root, fc1.window_start, fc1.window_end, fc1.payout, fc1.unlock_hash, fc1.revision_number
 			FROM file_contract_elements fc1
 			INNER JOIN last_contract_revision rev ON rev.contract_element_id = fc1.id
 			WHERE rev.ed25519_renter_key = ? OR rev.ed25519_host_key = ?`

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -106,10 +106,12 @@ CREATE TABLE last_contract_revision (
 	ed25519_renter_key BLOB,
 	ed25519_host_key BLOB,
 
-	confirmation_index BLOB NOT NULL,
+    confirmation_height BLOB NOT NULL,
+    confirmation_block_id BLOB NOT NULL REFERENCES blocks(id) ON DELETE CASCADE,
 	confirmation_transaction_id BLOB NOT NULL REFERENCES transactions(transaction_id),
 
-	proof_index BLOB,
+    proof_height BLOB,
+    proof_block_id BLOB,
 	proof_transaction_id BLOB REFERENCES transactions(transaction_id),
 
 	contract_element_id INTEGER UNIQUE REFERENCES file_contract_elements(id) ON DELETE CASCADE NOT NULL
@@ -452,10 +454,12 @@ CREATE INDEX v2_file_contract_elements_contract_id_revision_number_index ON v2_f
 CREATE TABLE v2_last_contract_revision (
     contract_id BLOB PRIMARY KEY NOT NULL,
 
-    confirmation_index BLOB NOT NULL,
+    confirmation_height BLOB NOT NULL,
+    confirmation_block_id BLOB NOT NULL REFERENCES blocks(id) ON DELETE CASCADE,
     confirmation_transaction_id BLOB NOT NULL REFERENCES v2_transactions(transaction_id),
 
-    resolution_index BLOB,
+    resolution_height BLOB,
+    resolution_block_id BLOB,
     resolution_transaction_id BLOB REFERENCES v2_transactions(transaction_id),
 
     contract_element_id INTEGER UNIQUE REFERENCES v2_file_contract_elements(id) ON DELETE CASCADE NOT NULL

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -106,8 +106,8 @@ CREATE TABLE last_contract_revision (
 	ed25519_renter_key BLOB,
 	ed25519_host_key BLOB,
 
-	confirmation_index BLOB,
-	confirmation_transaction_id BLOB REFERENCES transactions(transaction_id),
+	confirmation_index BLOB NOT NULL,
+	confirmation_transaction_id BLOB NOT NULL REFERENCES transactions(transaction_id),
 
 	proof_index BLOB,
 	proof_transaction_id BLOB REFERENCES transactions(transaction_id),
@@ -452,8 +452,8 @@ CREATE INDEX v2_file_contract_elements_contract_id_revision_number_index ON v2_f
 CREATE TABLE v2_last_contract_revision (
     contract_id BLOB PRIMARY KEY NOT NULL,
 
-    confirmation_index BLOB,
-    confirmation_transaction_id BLOB REFERENCES v2_transactions(transaction_id),
+    confirmation_index BLOB NOT NULL,
+    confirmation_transaction_id BLOB NOT NULL REFERENCES v2_transactions(transaction_id),
 
     resolution_index BLOB,
     resolution_transaction_id BLOB REFERENCES v2_transactions(transaction_id),

--- a/persist/sqlite/transactions.go
+++ b/persist/sqlite/transactions.go
@@ -284,7 +284,7 @@ type contractOrder struct {
 
 // transactionFileContracts returns the file contracts for each transaction.
 func transactionFileContracts(tx *txn, txnIDs []int64) (map[int64][]explorer.ExtendedFileContract, error) {
-	query := `SELECT ts.transaction_id, fc.id, rev.confirmation_index, rev.confirmation_transaction_id, rev.proof_index, rev.proof_transaction_id, fc.contract_id, fc.resolved, fc.valid, fc.transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
+	query := `SELECT ts.transaction_id, fc.id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc.contract_id, fc.resolved, fc.valid, fc.transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
 FROM file_contract_elements fc
 INNER JOIN transaction_file_contracts ts ON ts.contract_id = fc.id
 INNER JOIN last_contract_revision rev ON rev.contract_id = fc.contract_id
@@ -307,7 +307,7 @@ ORDER BY ts.transaction_order ASC`
 
 		var proofIndex types.ChainIndex
 		var proofTransactionID types.TransactionID
-		if err := rows.Scan(&txnID, &contractID, decode(&fc.ConfirmationIndex), decode(&fc.ConfirmationTransactionID), decodeNull(&proofIndex), decodeNull(&proofTransactionID), decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
+		if err := rows.Scan(&txnID, &contractID, decode(&fc.ConfirmationIndex.Height), decode(&fc.ConfirmationIndex.ID), decode(&fc.ConfirmationTransactionID), decodeNull(&proofIndex.Height), decodeNull(&proofIndex.ID), decodeNull(&proofTransactionID), decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
 			return nil, fmt.Errorf("failed to scan file contract: %w", err)
 		}
 
@@ -338,7 +338,7 @@ ORDER BY ts.transaction_order ASC`
 
 // transactionFileContracts returns the file contract revisions for each transaction.
 func transactionFileContractRevisions(tx *txn, txnIDs []int64) (map[int64][]explorer.FileContractRevision, error) {
-	query := `SELECT ts.transaction_id, fc.id, rev.confirmation_index, rev.confirmation_transaction_id, rev.proof_index, rev.proof_transaction_id, ts.parent_id, ts.unlock_conditions, fc.contract_id, fc.resolved, fc.valid, fc.transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
+	query := `SELECT ts.transaction_id, fc.id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, ts.parent_id, ts.unlock_conditions, fc.contract_id, fc.resolved, fc.valid, fc.transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
 FROM file_contract_elements fc
 INNER JOIN transaction_file_contract_revisions ts ON ts.contract_id = fc.id
 INNER JOIN last_contract_revision rev ON rev.contract_id = fc.contract_id
@@ -361,7 +361,7 @@ ORDER BY ts.transaction_order ASC`
 
 		var proofIndex types.ChainIndex
 		var proofTransactionID types.TransactionID
-		if err := rows.Scan(&txnID, &contractID, decode(&fc.ConfirmationIndex), decode(&fc.ConfirmationTransactionID), decodeNull(&proofIndex), decodeNull(&proofTransactionID), decode(&fc.ParentID), decode(&fc.UnlockConditions), decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.ExtendedFileContract.Filesize), decode(&fc.ExtendedFileContract.FileMerkleRoot), decode(&fc.ExtendedFileContract.WindowStart), decode(&fc.ExtendedFileContract.WindowEnd), decode(&fc.ExtendedFileContract.Payout), decode(&fc.ExtendedFileContract.UnlockHash), decode(&fc.ExtendedFileContract.RevisionNumber)); err != nil {
+		if err := rows.Scan(&txnID, &contractID, decode(&fc.ConfirmationIndex.Height), decode(&fc.ConfirmationIndex.ID), decode(&fc.ConfirmationTransactionID), decodeNull(&proofIndex.Height), decodeNull(&proofIndex.ID), decodeNull(&proofTransactionID), decode(&fc.ParentID), decode(&fc.UnlockConditions), decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.ExtendedFileContract.Filesize), decode(&fc.ExtendedFileContract.FileMerkleRoot), decode(&fc.ExtendedFileContract.WindowStart), decode(&fc.ExtendedFileContract.WindowEnd), decode(&fc.ExtendedFileContract.Payout), decode(&fc.ExtendedFileContract.UnlockHash), decode(&fc.ExtendedFileContract.RevisionNumber)); err != nil {
 			return nil, fmt.Errorf("failed to scan file contract: %w", err)
 		}
 

--- a/persist/sqlite/transactions.go
+++ b/persist/sqlite/transactions.go
@@ -305,17 +305,10 @@ ORDER BY ts.transaction_order ASC`
 		var txnID, contractID int64
 		var fc explorer.ExtendedFileContract
 
-		var confirmationIndex, proofIndex types.ChainIndex
-		var confirmationTransactionID, proofTransactionID types.TransactionID
-		if err := rows.Scan(&txnID, &contractID, decodeNull(&confirmationIndex), decodeNull(&confirmationTransactionID), decodeNull(&proofIndex), decodeNull(&proofTransactionID), decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
+		var proofIndex types.ChainIndex
+		var proofTransactionID types.TransactionID
+		if err := rows.Scan(&txnID, &contractID, decode(&fc.ConfirmationIndex), decode(&fc.ConfirmationTransactionID), decodeNull(&proofIndex), decodeNull(&proofTransactionID), decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.WindowStart), decode(&fc.WindowEnd), decode(&fc.Payout), decode(&fc.UnlockHash), decode(&fc.RevisionNumber)); err != nil {
 			return nil, fmt.Errorf("failed to scan file contract: %w", err)
-		}
-
-		if confirmationIndex != (types.ChainIndex{}) {
-			fc.ConfirmationIndex = &confirmationIndex
-		}
-		if confirmationTransactionID != (types.TransactionID{}) {
-			fc.ConfirmationTransactionID = &confirmationTransactionID
 		}
 
 		if proofIndex != (types.ChainIndex{}) {
@@ -366,17 +359,10 @@ ORDER BY ts.transaction_order ASC`
 		var txnID, contractID int64
 		var fc explorer.FileContractRevision
 
-		var confirmationIndex, proofIndex types.ChainIndex
-		var confirmationTransactionID, proofTransactionID types.TransactionID
-		if err := rows.Scan(&txnID, &contractID, decodeNull(&confirmationIndex), decodeNull(&confirmationTransactionID), decodeNull(&proofIndex), decodeNull(&proofTransactionID), decode(&fc.ParentID), decode(&fc.UnlockConditions), decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.ExtendedFileContract.Filesize), decode(&fc.ExtendedFileContract.FileMerkleRoot), decode(&fc.ExtendedFileContract.WindowStart), decode(&fc.ExtendedFileContract.WindowEnd), decode(&fc.ExtendedFileContract.Payout), decode(&fc.ExtendedFileContract.UnlockHash), decode(&fc.ExtendedFileContract.RevisionNumber)); err != nil {
+		var proofIndex types.ChainIndex
+		var proofTransactionID types.TransactionID
+		if err := rows.Scan(&txnID, &contractID, decode(&fc.ConfirmationIndex), decode(&fc.ConfirmationTransactionID), decodeNull(&proofIndex), decodeNull(&proofTransactionID), decode(&fc.ParentID), decode(&fc.UnlockConditions), decode(&fc.ID), &fc.Resolved, &fc.Valid, decode(&fc.TransactionID), decode(&fc.ExtendedFileContract.Filesize), decode(&fc.ExtendedFileContract.FileMerkleRoot), decode(&fc.ExtendedFileContract.WindowStart), decode(&fc.ExtendedFileContract.WindowEnd), decode(&fc.ExtendedFileContract.Payout), decode(&fc.ExtendedFileContract.UnlockHash), decode(&fc.ExtendedFileContract.RevisionNumber)); err != nil {
 			return nil, fmt.Errorf("failed to scan file contract: %w", err)
-		}
-
-		if confirmationIndex != (types.ChainIndex{}) {
-			fc.ConfirmationIndex = &confirmationIndex
-		}
-		if confirmationTransactionID != (types.TransactionID{}) {
-			fc.ConfirmationTransactionID = &confirmationTransactionID
 		}
 
 		if proofIndex != (types.ChainIndex{}) {

--- a/persist/sqlite/v2consensus_test.go
+++ b/persist/sqlite/v2consensus_test.go
@@ -1019,6 +1019,8 @@ func TestV2FileContractResolution(t *testing.T) {
 	}
 	syncDB(t, db, cm)
 
+	tip1 := cm.Tip()
+
 	v2FC0ID := txn1.V2FileContractID(txn1.ID(), 0)
 	v2FC1ID := txn1.V2FileContractID(txn1.ID(), 1)
 	v2FC2ID := txn1.V2FileContractID(txn1.ID(), 2)
@@ -1091,8 +1093,14 @@ func TestV2FileContractResolution(t *testing.T) {
 			t.Fatal(err)
 		}
 		testutil.CheckV2Transaction(t, txn2, dbTxns[0])
+
+		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
+		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn2.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
+
+		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[1].Parent.ConfirmationIndex)
+		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[1].Parent.ConfirmationTransactionID)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[1].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn2.ID(), *dbTxns[0].FileContractResolutions[1].Parent.ResolutionTransactionID)
 	}
@@ -1130,6 +1138,8 @@ func TestV2FileContractResolution(t *testing.T) {
 			t.Fatal(err)
 		}
 		testutil.CheckV2Transaction(t, txn3, dbTxns[0])
+		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
+		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn3.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}
@@ -1155,6 +1165,8 @@ func TestV2FileContractResolution(t *testing.T) {
 			t.Fatal(err)
 		}
 		testutil.CheckV2Transaction(t, txn4, dbTxns[0])
+		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
+		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn4.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}
@@ -1213,6 +1225,8 @@ func TestV2FileContractResolution(t *testing.T) {
 			t.Fatal(err)
 		}
 		testutil.CheckV2Transaction(t, txn2, dbTxns[0])
+		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
+		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn2.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}
@@ -1238,6 +1252,8 @@ func TestV2FileContractResolution(t *testing.T) {
 			t.Fatal(err)
 		}
 		testutil.CheckV2Transaction(t, txn3, dbTxns[0])
+		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
+		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn3.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}
@@ -1256,6 +1272,8 @@ func TestV2FileContractResolution(t *testing.T) {
 			t.Fatal(err)
 		}
 		testutil.CheckV2Transaction(t, txn4, dbTxns[0])
+		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
+		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn4.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}

--- a/persist/sqlite/v2contracts.go
+++ b/persist/sqlite/v2contracts.go
@@ -8,22 +8,16 @@ import (
 )
 
 func scanV2FileContract(s scanner) (fce explorer.V2FileContract, err error) {
-	var confirmationIndex, resolutionIndex types.ChainIndex
-	var confirmationTransactionID, resolutionTransactionID types.TransactionID
+	var resolutionIndex types.ChainIndex
+	var resolutionTransactionID types.TransactionID
 
 	fc := &fce.V2FileContractElement.V2FileContract
-	if err = s.Scan(decode(&fce.TransactionID), decodeNull(&confirmationIndex), decodeNull(&confirmationTransactionID), decodeNull(&resolutionIndex), decodeNull(&resolutionTransactionID), decode(&fce.V2FileContractElement.ID), decode(&fce.V2FileContractElement.StateElement.LeafIndex), decode(&fc.Capacity), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.ProofHeight), decode(&fc.ExpirationHeight), decode(&fc.RenterOutput.Address), decode(&fc.RenterOutput.Value), decode(&fc.HostOutput.Address), decode(&fc.HostOutput.Value), decode(&fc.MissedHostValue), decode(&fc.TotalCollateral), decode(&fc.RenterPublicKey), decode(&fc.HostPublicKey), decode(&fc.RevisionNumber), decode(&fc.RenterSignature), decode(&fc.HostSignature)); err != nil {
+	if err = s.Scan(decode(&fce.TransactionID), decode(&fce.ConfirmationIndex), decode(&fce.ConfirmationTransactionID), decodeNull(&resolutionIndex), decodeNull(&resolutionTransactionID), decode(&fce.V2FileContractElement.ID), decode(&fce.V2FileContractElement.StateElement.LeafIndex), decode(&fc.Capacity), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.ProofHeight), decode(&fc.ExpirationHeight), decode(&fc.RenterOutput.Address), decode(&fc.RenterOutput.Value), decode(&fc.HostOutput.Address), decode(&fc.HostOutput.Value), decode(&fc.MissedHostValue), decode(&fc.TotalCollateral), decode(&fc.RenterPublicKey), decode(&fc.HostPublicKey), decode(&fc.RevisionNumber), decode(&fc.RenterSignature), decode(&fc.HostSignature)); err != nil {
 		return
 	}
 
-	if confirmationIndex != (types.ChainIndex{}) {
-		fce.ConfirmationIndex = &confirmationIndex
-	}
 	if resolutionIndex != (types.ChainIndex{}) {
 		fce.ResolutionIndex = &resolutionIndex
-	}
-	if confirmationTransactionID != (types.TransactionID{}) {
-		fce.ConfirmationTransactionID = &confirmationTransactionID
 	}
 	if resolutionTransactionID != (types.TransactionID{}) {
 		fce.ResolutionTransactionID = &resolutionTransactionID

--- a/persist/sqlite/v2contracts.go
+++ b/persist/sqlite/v2contracts.go
@@ -12,7 +12,7 @@ func scanV2FileContract(s scanner) (fce explorer.V2FileContract, err error) {
 	var resolutionTransactionID types.TransactionID
 
 	fc := &fce.V2FileContractElement.V2FileContract
-	if err = s.Scan(decode(&fce.TransactionID), decode(&fce.ConfirmationIndex), decode(&fce.ConfirmationTransactionID), decodeNull(&resolutionIndex), decodeNull(&resolutionTransactionID), decode(&fce.V2FileContractElement.ID), decode(&fce.V2FileContractElement.StateElement.LeafIndex), decode(&fc.Capacity), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.ProofHeight), decode(&fc.ExpirationHeight), decode(&fc.RenterOutput.Address), decode(&fc.RenterOutput.Value), decode(&fc.HostOutput.Address), decode(&fc.HostOutput.Value), decode(&fc.MissedHostValue), decode(&fc.TotalCollateral), decode(&fc.RenterPublicKey), decode(&fc.HostPublicKey), decode(&fc.RevisionNumber), decode(&fc.RenterSignature), decode(&fc.HostSignature)); err != nil {
+	if err = s.Scan(decode(&fce.TransactionID), decode(&fce.ConfirmationIndex.Height), decode(&fce.ConfirmationIndex.ID), decode(&fce.ConfirmationTransactionID), decodeNull(&resolutionIndex.Height), decodeNull(&resolutionIndex.ID), decodeNull(&resolutionTransactionID), decode(&fce.V2FileContractElement.ID), decode(&fce.V2FileContractElement.StateElement.LeafIndex), decode(&fc.Capacity), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.ProofHeight), decode(&fc.ExpirationHeight), decode(&fc.RenterOutput.Address), decode(&fc.RenterOutput.Value), decode(&fc.HostOutput.Address), decode(&fc.HostOutput.Value), decode(&fc.MissedHostValue), decode(&fc.TotalCollateral), decode(&fc.RenterPublicKey), decode(&fc.HostPublicKey), decode(&fc.RevisionNumber), decode(&fc.RenterSignature), decode(&fc.HostSignature)); err != nil {
 		return
 	}
 
@@ -29,7 +29,7 @@ func scanV2FileContract(s scanner) (fce explorer.V2FileContract, err error) {
 // V2Contracts implements explorer.Store.
 func (s *Store) V2Contracts(ids []types.FileContractID) (result []explorer.V2FileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		stmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.resolution_index, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+		stmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_last_contract_revision rev
 INNER JOIN v2_file_contract_elements fc ON rev.contract_element_id = fc.id
 WHERE rev.contract_id = ?
@@ -56,7 +56,7 @@ WHERE rev.contract_id = ?
 // V2ContractRevisions implements explorer.Store.
 func (s *Store) V2ContractRevisions(id types.FileContractID) (revisions []explorer.V2FileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		query := `SELECT fc.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.resolution_index, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+		query := `SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_last_contract_revision rev ON rev.contract_id = fc.contract_id
 WHERE fc.contract_id = ?
@@ -89,11 +89,11 @@ ORDER BY fc.revision_number ASC
 func (s *Store) V2ContractsKey(key types.PublicKey) (result []explorer.V2FileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
 		encoded := encode(key)
-		rows, err := tx.Query(`SELECT fc.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.resolution_index, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+		rows, err := tx.Query(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_last_contract_revision rev
 INNER JOIN v2_file_contract_elements fc ON rev.contract_element_id = fc.id
 WHERE fc.renter_public_key = ? OR fc.host_public_key = ?
-ORDER BY rev.confirmation_index ASC
+ORDER BY rev.confirmation_height ASC
 `, encoded, encoded)
 		if err != nil {
 			return err

--- a/persist/sqlite/v2transactions.go
+++ b/persist/sqlite/v2transactions.go
@@ -322,7 +322,7 @@ ORDER BY ts.transaction_order ASC`)
 // fillV2TransactionFileContracts fills in the file contracts for each
 // transaction.
 func fillV2TransactionFileContracts(tx *txn, dbIDs []int64, txns []explorer.V2Transaction) error {
-	stmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.resolution_index, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+	stmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_transaction_file_contracts ts ON (ts.contract_id = fc.id)
 INNER JOIN v2_last_contract_revision rev ON (rev.contract_id = fc.contract_id)
@@ -361,7 +361,7 @@ ORDER BY ts.transaction_order ASC`)
 // fillV2TransactionFileContractRevisions fills in the file contract revisions
 // for each transaction.
 func fillV2TransactionFileContractRevisions(tx *txn, dbIDs []int64, txns []explorer.V2Transaction) error {
-	parentStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.resolution_index, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+	parentStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_transaction_file_contract_revisions ts ON (ts.parent_contract_id = fc.id)
 INNER JOIN v2_last_contract_revision rev ON (rev.contract_id = fc.contract_id)
@@ -372,7 +372,7 @@ ORDER BY ts.transaction_order ASC`)
 	}
 	defer parentStmt.Close()
 
-	revisionStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.resolution_index, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+	revisionStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_transaction_file_contract_revisions ts ON (ts.revision_contract_id = fc.id)
 INNER JOIN v2_last_contract_revision rev ON (rev.contract_id = fc.contract_id)
@@ -448,7 +448,7 @@ func fillV2TransactionFileContractResolutions(tx *txn, dbIDs []int64, txns []exp
 	defer consolidatedStmt.Close()
 
 	// get a v2 FC by id
-	fcStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_index, rev.confirmation_transaction_id, rev.resolution_index, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+	fcStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_last_contract_revision rev ON (rev.contract_id = fc.contract_id)
 WHERE fc.id = ?`)


### PR DESCRIPTION
Unlike with proofs or resolutions, a contract is guaranteed to be confirmed once it is in the database.  Previously this data was stored as nullable to make it convenient to update alongside resolution index / resolution transaction ID in `updateFileContractIndices`/`updateV2FileContractIndices`.  We also split the the chain index into separate fields, i.e.

```
-- excerpted from `last_contract_revision` / `v2_last_contract_revision`
    confirmation_height BLOB NOT NULL,
    confirmation_block_id BLOB NOT NULL REFERENCES blocks(id) ON DELETE CASCADE,
```

So that we can have a direct reference to the block.

Note: Base of this branch is v2 to avoid complicated rebasing once that's merged but it's not really a v2 feature so I don't think it needs to be merged into there.
