### PR TITLE
Panic on index error

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -138,8 +138,7 @@ func NewExplorer(cm ChainManager, store Store, batchSize int, scanCfg config.Sca
 				e.log.Error("failed to get tip", zap.Error(err))
 			}
 			if err := e.syncStore(lastTip, batchSize); err != nil {
-				e.log.Error("failed to sync store", zap.Error(err))
-				panic(err)
+				e.log.Panic("failed to sync store", zap.Error(err))
 			}
 		}
 	}()

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -139,6 +139,7 @@ func NewExplorer(cm ChainManager, store Store, batchSize int, scanCfg config.Sca
 			}
 			if err := e.syncStore(lastTip, batchSize); err != nil {
 				e.log.Error("failed to sync store", zap.Error(err))
+				panic(err)
 			}
 		}
 	}()


### PR DESCRIPTION
Panic when we fail to index the data.  This means either there's an erroneous query or the database is out of date and needs to be rescanned anyways.  I leave the logging because panic doesn't give timestamps.