### PR TITLE
Use coreutils/wallet.Event

### DIFF
--- a/explorer/events.go
+++ b/explorer/events.go
@@ -19,10 +19,6 @@ type (
 	// siafund elements.
 	EventV1Transaction struct {
 		Transaction Transaction `json:"transaction"`
-		// v1 siacoin inputs do not describe the value of the spent utxo
-		SpentSiacoinElements []SiacoinOutput `json:"spentSiacoinElements,omitempty"`
-		// v1 siafund inputs do not describe the value of the spent utxo
-		SpentSiafundElements []SiacoinOutput `json:"spentSiafundElements,omitempty"`
 	}
 
 	// An EventV1ContractResolution represents a file contract payout from a v1
@@ -122,7 +118,6 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) (events []
 				continue
 			}
 
-			// e.SpentSiacoinElements = append(e.SpentSiacoinElements, sce)
 			addresses[sce.SiacoinOutput.Address] = struct{}{}
 		}
 		for _, sco := range txn.SiacoinOutputs {
@@ -135,7 +130,6 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) (events []
 				continue
 			}
 
-			// e.SpentSiafundElements = append(e.SpentSiafundElements, sfe)
 			addresses[sfe.SiafundOutput.Address] = struct{}{}
 
 			sce, ok := sces[sfi.ParentID.ClaimOutputID()]

--- a/explorer/events.go
+++ b/explorer/events.go
@@ -275,9 +275,8 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) (events []
 			panic("unknown resolution type")
 		}
 
-		efc := V2FileContract{V2FileContractElement: fce}
-		{
-			element := sces[types.FileContractID(fce.ID).V2HostOutputID()]
+		addV2Resolution := func(element types.SiacoinElement) {
+			efc := V2FileContract{V2FileContractElement: fce}
 			addEvent(types.Hash256(element.ID), element.MaturityHeight, wallet.EventTypeV2ContractResolution, EventV2ContractResolution{
 				Resolution: V2FileContractResolution{
 					Parent:     efc,
@@ -286,21 +285,10 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) (events []
 				},
 				SiacoinElement: SiacoinOutput{SiacoinElement: element},
 				Missed:         missed,
-			}, []types.Address{fce.V2FileContract.HostOutput.Address})
+			}, []types.Address{element.SiacoinOutput.Address})
 		}
-
-		{
-			element := sces[types.FileContractID(fce.ID).V2RenterOutputID()]
-			addEvent(types.Hash256(element.ID), element.MaturityHeight, wallet.EventTypeV2ContractResolution, EventV2ContractResolution{
-				Resolution: V2FileContractResolution{
-					Parent:     efc,
-					Type:       typ,
-					Resolution: res,
-				},
-				SiacoinElement: SiacoinOutput{SiacoinElement: element},
-				Missed:         missed,
-			}, []types.Address{fce.V2FileContract.RenterOutput.Address})
-		}
+		addV2Resolution(sces[types.FileContractID(fce.ID).V2RenterOutputID()])
+		addV2Resolution(sces[types.FileContractID(fce.ID).V2HostOutputID()])
 	})
 
 	// handle block rewards

--- a/explorer/events.go
+++ b/explorer/events.go
@@ -5,104 +5,69 @@ import (
 
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/wallet"
 )
 
-// event type constants
-const (
-	EventTypeTransaction       = "transaction"
-	EventTypeV2Transaction     = "v2transaction"
-	EventTypeMinerPayout       = "miner payout"
-	EventTypeContractPayout    = "contract payout"
-	EventTypeSiafundClaim      = "siafund claim"
-	EventTypeFoundationSubsidy = "foundation subsidy"
+type (
+	// An EventPayout represents a miner payout, siafund claim, or foundation
+	// subsidy.
+	EventPayout struct {
+		SiacoinElement SiacoinOutput `json:"siacoinElement"`
+	}
+
+	// An EventV1Transaction pairs a v1 transaction with its spent siacoin and
+	// siafund elements.
+	EventV1Transaction struct {
+		Transaction Transaction `json:"transaction"`
+		// v1 siacoin inputs do not describe the value of the spent utxo
+		SpentSiacoinElements []SiacoinOutput `json:"spentSiacoinElements,omitempty"`
+		// v1 siafund inputs do not describe the value of the spent utxo
+		SpentSiafundElements []SiacoinOutput `json:"spentSiafundElements,omitempty"`
+	}
+
+	// An EventV1ContractResolution represents a file contract payout from a v1
+	// contract.
+	EventV1ContractResolution struct {
+		Parent         ExtendedFileContract `json:"parent"`
+		SiacoinElement SiacoinOutput        `json:"siacoinElement"`
+		Missed         bool                 `json:"missed"`
+	}
+
+	// An EventV2ContractResolution represents a file contract payout from a v2
+	// contract.
+	EventV2ContractResolution struct {
+		Resolution     V2FileContractResolution `json:"resolution"`
+		SiacoinElement SiacoinOutput            `json:"siacoinElement"`
+		Missed         bool                     `json:"missed"`
+	}
+
+	// EventV2Transaction is a transaction event that includes the transaction
+	EventV2Transaction V2Transaction
+
+	// EventData contains the data associated with an event.
+	EventData interface {
+		isEvent() bool
+	}
+
+	// An Event is a transaction or other event that affects the wallet including
+	// miner payouts, siafund claims, and file contract payouts.
+	Event struct {
+		ID             types.Hash256    `json:"id"`
+		Index          types.ChainIndex `json:"index"`
+		Confirmations  uint64           `json:"confirmations"`
+		Type           string           `json:"type"`
+		Data           EventData        `json:"data"`
+		MaturityHeight uint64           `json:"maturityHeight"`
+		Timestamp      time.Time        `json:"timestamp"`
+		Relevant       []types.Address  `json:"relevant,omitempty"`
+	}
 )
 
-// Arbitrary data specifiers
-var (
-	SpecifierAnnouncement = types.NewSpecifier("HostAnnouncement")
-)
-
-type eventData interface {
-	EventType() string
-}
-
-// An Event is something interesting that happened on the Sia blockchain.
-type Event struct {
-	ID             types.Hash256    `json:"id"`
-	Index          types.ChainIndex `json:"index"`
-	Timestamp      time.Time        `json:"timestamp"`
-	MaturityHeight uint64           `json:"maturityHeight"`
-	Addresses      []types.Address  `json:"addresses"`
-	Data           eventData        `json:"data"`
-}
-
-// EventType implements Event.
-func (*EventTransaction) EventType() string { return EventTypeTransaction }
-
-// EventType implements Event.
-func (*EventV2Transaction) EventType() string { return EventTypeV2Transaction }
-
-// EventType implements Event.
-func (*EventMinerPayout) EventType() string { return EventTypeMinerPayout }
-
-// EventType implements Event.
-func (*EventFoundationSubsidy) EventType() string { return EventTypeFoundationSubsidy }
-
-// EventType implements Event.
-func (*EventContractPayout) EventType() string { return EventTypeContractPayout }
-
-// An EventSiafundInput represents a siafund input within an EventTransaction.
-type EventSiafundInput struct {
-	SiafundElement types.SiafundElement `json:"siafundElement"`
-	ClaimElement   types.SiacoinElement `json:"claimElement"`
-}
-
-// An EventFileContract represents a file contract within an EventTransaction.
-type EventFileContract struct {
-	FileContract types.FileContractElement `json:"fileContract"`
-	// only non-nil if transaction revised contract
-	Revision *types.FileContract `json:"revision,omitempty"`
-	// only non-nil if transaction resolved contract
-	ValidOutputs []types.SiacoinElement `json:"validOutputs,omitempty"`
-}
-
-// An EventV2FileContract represents a v2 file contract within an EventTransaction.
-type EventV2FileContract struct {
-	FileContract types.V2FileContractElement `json:"fileContract"`
-	// only non-nil if transaction revised contract
-	Revision *types.V2FileContract `json:"revision,omitempty"`
-	// only non-nil if transaction resolved contract
-	Resolution types.V2FileContractResolutionType `json:"resolution,omitempty"`
-	Outputs    []types.SiacoinElement             `json:"outputs,omitempty"`
-}
-
-// An EventTransaction represents a transaction that affects the wallet.
-type EventTransaction struct {
-	Transaction       Transaction              `json:"transaction"`
-	HostAnnouncements []chain.HostAnnouncement `json:"hostAnnouncements"`
-	Fee               types.Currency           `json:"fee"`
-}
-
-// An EventV2Transaction represents a v2 transaction that affects the wallet.
-type EventV2Transaction V2Transaction
-
-// An EventMinerPayout represents a miner payout from a block.
-type EventMinerPayout struct {
-	SiacoinOutput types.SiacoinElement `json:"siacoinOutput"`
-}
-
-// EventFoundationSubsidy represents a foundation subsidy from a block.
-type EventFoundationSubsidy struct {
-	SiacoinOutput types.SiacoinElement `json:"siacoinOutput"`
-}
-
-// An EventContractPayout represents a file contract payout
-type EventContractPayout struct {
-	FileContract  types.FileContractElement `json:"fileContract"`
-	SiacoinOutput types.SiacoinElement      `json:"siacoinOutput"`
-	Missed        bool                      `json:"missed"`
-}
+func (EventPayout) isEvent() bool               { return true }
+func (EventV1Transaction) isEvent() bool        { return true }
+func (EventV1ContractResolution) isEvent() bool { return true }
+func (EventV2Transaction) isEvent() bool        { return true }
+func (EventV2ContractResolution) isEvent() bool { return true }
 
 // A ChainUpdate is a set of changes to the consensus state.
 type ChainUpdate interface {
@@ -113,13 +78,12 @@ type ChainUpdate interface {
 }
 
 // AppliedEvents extracts a list of relevant events from a chain update.
-func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) []Event {
-	var events []Event
-	addEvent := func(id types.Hash256, maturityHeight uint64, v eventData, addresses []types.Address) {
+func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) (events []Event) {
+	addEvent := func(id types.Hash256, maturityHeight uint64, eventType string, v EventData, relevant []types.Address) {
 		// dedup relevant addresses
 		seen := make(map[types.Address]bool)
-		unique := addresses[:0]
-		for _, addr := range addresses {
+		unique := relevant[:0]
+		for _, addr := range relevant {
 			if !seen[addr] {
 				unique = append(unique, addr)
 				seen[addr] = true
@@ -131,7 +95,8 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) []Event {
 			Timestamp:      b.Timestamp,
 			Index:          cs.Index,
 			MaturityHeight: maturityHeight,
-			Addresses:      unique,
+			Relevant:       unique,
+			Type:           eventType,
 			Data:           v,
 		})
 	}
@@ -139,136 +104,225 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) []Event {
 	// collect all elements
 	sces := make(map[types.SiacoinOutputID]types.SiacoinElement)
 	sfes := make(map[types.SiafundOutputID]types.SiafundElement)
-	fces := make(map[types.FileContractID]types.FileContractElement)
-	v2fces := make(map[types.FileContractID]types.V2FileContractElement)
-	cu.ForEachSiacoinElement(func(sce types.SiacoinElement, created, spent bool) {
+	cu.ForEachSiacoinElement(func(sce types.SiacoinElement, _, _ bool) {
 		sce.StateElement.MerkleProof = nil
-		sces[sce.ID] = sce
+		sces[types.SiacoinOutputID(sce.ID)] = sce
 	})
-	cu.ForEachSiafundElement(func(sfe types.SiafundElement, created, spent bool) {
+	cu.ForEachSiafundElement(func(sfe types.SiafundElement, _, _ bool) {
 		sfe.StateElement.MerkleProof = nil
-		sfes[sfe.ID] = sfe
+		sfes[types.SiafundOutputID(sfe.ID)] = sfe
 	})
-	cu.ForEachFileContractElement(func(fce types.FileContractElement, created bool, rev *types.FileContractElement, resolved, valid bool) {
-		fce.StateElement.MerkleProof = nil
-		fces[fce.ID] = fce
-	})
-	cu.ForEachV2FileContractElement(func(fce types.V2FileContractElement, created bool, rev *types.V2FileContractElement, res types.V2FileContractResolutionType) {
-		fce.StateElement.MerkleProof = nil
-		v2fces[fce.ID] = fce
-	})
-
-	relevantTxn := func(txn types.Transaction) (addrs []types.Address) {
-		for _, sci := range txn.SiacoinInputs {
-			addrs = append(addrs, sces[sci.ParentID].SiacoinOutput.Address)
-		}
-		for _, sco := range txn.SiacoinOutputs {
-			addrs = append(addrs, sco.Address)
-		}
-		for _, sfi := range txn.SiafundInputs {
-			addrs = append(addrs, sfes[sfi.ParentID].SiafundOutput.Address)
-		}
-		for _, sfo := range txn.SiafundOutputs {
-			addrs = append(addrs, sfo.Address)
-		}
-		return
-	}
-
-	relevantV2Txn := func(txn types.V2Transaction) (addrs []types.Address) {
-		for _, sci := range txn.SiacoinInputs {
-			addrs = append(addrs, sci.Parent.SiacoinOutput.Address)
-		}
-		for _, sco := range txn.SiacoinOutputs {
-			addrs = append(addrs, sco.Address)
-		}
-		for _, sfi := range txn.SiafundInputs {
-			addrs = append(addrs, sfi.Parent.SiafundOutput.Address)
-		}
-		for _, sfo := range txn.SiafundOutputs {
-			addrs = append(addrs, sfo.Address)
-		}
-		return
-	}
 
 	// handle v1 transactions
 	for _, txn := range b.Transactions {
-		relevant := relevantTxn(txn)
+		addresses := make(map[types.Address]struct{})
+		for _, sci := range txn.SiacoinInputs {
+			sce, ok := sces[sci.ParentID]
+			if !ok {
+				continue
+			}
 
-		var e EventTransaction
-		for _, arb := range txn.ArbitraryData {
-			var ha chain.HostAnnouncement
-			if ha.FromArbitraryData(arb) {
-				e.HostAnnouncements = append(e.HostAnnouncements, ha)
+			// e.SpentSiacoinElements = append(e.SpentSiacoinElements, sce)
+			addresses[sce.SiacoinOutput.Address] = struct{}{}
+		}
+		for _, sco := range txn.SiacoinOutputs {
+			addresses[sco.Address] = struct{}{}
+		}
+
+		for _, sfi := range txn.SiafundInputs {
+			sfe, ok := sfes[sfi.ParentID]
+			if !ok {
+				continue
+			}
+
+			// e.SpentSiafundElements = append(e.SpentSiafundElements, sfe)
+			addresses[sfe.SiafundOutput.Address] = struct{}{}
+
+			sce, ok := sces[sfi.ParentID.ClaimOutputID()]
+			if ok {
+				addEvent(types.Hash256(sce.ID), sce.MaturityHeight, wallet.EventTypeSiafundClaim, EventPayout{
+					SiacoinElement: SiacoinOutput{SiacoinElement: sce},
+				}, []types.Address{sfi.ClaimAddress})
 			}
 		}
-
-		for i := range txn.MinerFees {
-			e.Fee = e.Fee.Add(txn.MinerFees[i])
+		for _, sfo := range txn.SiafundOutputs {
+			addresses[sfo.Address] = struct{}{}
 		}
 
-		addEvent(types.Hash256(txn.ID()), cs.Index.Height, &e, relevant) // transaction maturity height is the current block height
+		for _, fc := range txn.FileContracts {
+			addresses[fc.UnlockHash] = struct{}{}
+			for _, vpo := range fc.ValidProofOutputs {
+				addresses[vpo.Address] = struct{}{}
+			}
+			for _, mpo := range fc.MissedProofOutputs {
+				addresses[mpo.Address] = struct{}{}
+			}
+		}
+		// skip transactions with no relevant addresses
+		if len(addresses) == 0 {
+			continue
+		}
+
+		var ev EventV1Transaction
+		relevant := make([]types.Address, 0, len(addresses))
+		for addr := range addresses {
+			relevant = append(relevant, addr)
+		}
+
+		addEvent(types.Hash256(txn.ID()), cs.Index.Height, wallet.EventTypeV1Transaction, ev, relevant) // transaction maturity height is the current block height
 	}
 
 	// handle v2 transactions
 	for _, txn := range b.V2Transactions() {
-		relevant := relevantV2Txn(txn)
+		addresses := make(map[types.Address]struct{})
+		for _, sci := range txn.SiacoinInputs {
+			addresses[sci.Parent.SiacoinOutput.Address] = struct{}{}
+		}
+		for _, sco := range txn.SiacoinOutputs {
+			addresses[sco.Address] = struct{}{}
+		}
+		for _, sfi := range txn.SiafundInputs {
+			addresses[sfi.Parent.SiafundOutput.Address] = struct{}{}
 
-		var e EventV2Transaction
-		for _, a := range txn.Attestations {
-			var ha chain.V2HostAnnouncement
-			if ha.FromAttestation(a) == nil {
-				e.HostAnnouncements = append(e.HostAnnouncements, V2HostAnnouncement{
-					PublicKey:          a.PublicKey,
-					V2HostAnnouncement: ha,
-				})
+			sce, ok := sces[types.SiafundOutputID(sfi.Parent.ID).V2ClaimOutputID()]
+			if ok {
+				addEvent(types.Hash256(sce.ID), sce.MaturityHeight, wallet.EventTypeSiafundClaim, EventPayout{
+					SiacoinElement: SiacoinOutput{SiacoinElement: sce},
+				}, []types.Address{sfi.ClaimAddress})
 			}
 		}
+		for _, sco := range txn.SiafundOutputs {
+			addresses[sco.Address] = struct{}{}
+		}
 
-		addEvent(types.Hash256(txn.ID()), cs.Index.Height, &e, relevant) // transaction maturity height is the current block height
+		// ev := EventV2Transaction(txn)
+		var ev EventV2Transaction
+		relevant := make([]types.Address, 0, len(addresses))
+		for addr := range addresses {
+			relevant = append(relevant, addr)
+		}
+		addEvent(types.Hash256(txn.ID()), cs.Index.Height, wallet.EventTypeV2Transaction, ev, relevant) // transaction maturity height is the current block height
 	}
 
-	// handle missed contracts
-	cu.ForEachFileContractElement(func(fce types.FileContractElement, created bool, rev *types.FileContractElement, resolved, valid bool) {
+	// handle contracts
+	cu.ForEachFileContractElement(func(fce types.FileContractElement, _ bool, rev *types.FileContractElement, resolved, valid bool) {
 		if !resolved {
 			return
 		}
 
+		fce.StateElement.MerkleProof = nil
+
+		var mpos, vpos []ContractSiacoinOutput
+		for _, mpo := range fce.FileContract.MissedProofOutputs {
+			mpos = append(mpos, ContractSiacoinOutput{SiacoinOutput: mpo})
+		}
+		for _, vpo := range fce.FileContract.ValidProofOutputs {
+			vpos = append(vpos, ContractSiacoinOutput{SiacoinOutput: vpo})
+		}
+		efc := ExtendedFileContract{
+			ID:                 fce.ID,
+			Filesize:           fce.FileContract.Filesize,
+			FileMerkleRoot:     fce.FileContract.FileMerkleRoot,
+			WindowStart:        fce.FileContract.WindowStart,
+			WindowEnd:          fce.FileContract.WindowEnd,
+			Payout:             fce.FileContract.Payout,
+			ValidProofOutputs:  vpos,
+			MissedProofOutputs: mpos,
+			UnlockHash:         fce.FileContract.UnlockHash,
+			RevisionNumber:     fce.FileContract.RevisionNumber,
+		}
+
 		if valid {
 			for i := range fce.FileContract.ValidProofOutputs {
-				outputID := fce.ID.ValidOutputID(i)
-				addEvent(types.Hash256(outputID), cs.MaturityHeight(), &EventContractPayout{
-					FileContract:  fce,
-					SiacoinOutput: sces[outputID],
-					Missed:        false,
-				}, []types.Address{fce.FileContract.ValidProofOutputs[i].Address})
+				address := fce.FileContract.ValidProofOutputs[i].Address
+				element := sces[types.FileContractID(fce.ID).ValidOutputID(i)]
+
+				addEvent(types.Hash256(element.ID), element.MaturityHeight, wallet.EventTypeV1ContractResolution, EventV1ContractResolution{
+					Parent:         efc,
+					SiacoinElement: SiacoinOutput{SiacoinElement: element},
+					Missed:         false,
+				}, []types.Address{address})
 			}
 		} else {
 			for i := range fce.FileContract.MissedProofOutputs {
-				outputID := fce.ID.MissedOutputID(i)
-				addEvent(types.Hash256(outputID), cs.MaturityHeight(), &EventContractPayout{
-					FileContract:  fce,
-					SiacoinOutput: sces[outputID],
-					Missed:        true,
-				}, []types.Address{fce.FileContract.MissedProofOutputs[i].Address})
+				address := fce.FileContract.MissedProofOutputs[i].Address
+				element := sces[types.FileContractID(fce.ID).MissedOutputID(i)]
+
+				addEvent(types.Hash256(element.ID), element.MaturityHeight, wallet.EventTypeV1ContractResolution, EventV1ContractResolution{
+					Parent:         efc,
+					SiacoinElement: SiacoinOutput{SiacoinElement: element},
+					Missed:         true,
+				}, []types.Address{address})
 			}
+		}
+	})
+
+	cu.ForEachV2FileContractElement(func(fce types.V2FileContractElement, _ bool, rev *types.V2FileContractElement, res types.V2FileContractResolutionType) {
+		if res == nil {
+			return
+		}
+
+		fce.StateElement.MerkleProof = nil
+
+		var missed bool
+		if _, ok := res.(*types.V2FileContractExpiration); ok {
+			missed = true
+		}
+
+		var typ string
+		switch res.(type) {
+		case *types.V2FileContractRenewal:
+			typ = "renewal"
+		case *types.V2StorageProof:
+			typ = "storageProof"
+		case *types.V2FileContractExpiration:
+			typ = "expiration"
+		default:
+			panic("unknown resolution type")
+		}
+
+		efc := V2FileContract{V2FileContractElement: fce}
+		{
+			element := sces[types.FileContractID(fce.ID).V2HostOutputID()]
+			addEvent(types.Hash256(element.ID), element.MaturityHeight, wallet.EventTypeV2ContractResolution, EventV2ContractResolution{
+				Resolution: V2FileContractResolution{
+					Parent:     efc,
+					Type:       typ,
+					Resolution: res,
+				},
+				SiacoinElement: SiacoinOutput{SiacoinElement: element},
+				Missed:         missed,
+			}, []types.Address{fce.V2FileContract.HostOutput.Address})
+		}
+
+		{
+			element := sces[types.FileContractID(fce.ID).V2RenterOutputID()]
+			addEvent(types.Hash256(element.ID), element.MaturityHeight, wallet.EventTypeV2ContractResolution, EventV2ContractResolution{
+				Resolution: V2FileContractResolution{
+					Parent:     efc,
+					Type:       typ,
+					Resolution: res,
+				},
+				SiacoinElement: SiacoinOutput{SiacoinElement: element},
+				Missed:         missed,
+			}, []types.Address{fce.V2FileContract.RenterOutput.Address})
 		}
 	})
 
 	// handle block rewards
 	for i := range b.MinerPayouts {
-		outputID := cs.Index.ID.MinerOutputID(i)
-		addEvent(types.Hash256(outputID), cs.MaturityHeight(), &EventMinerPayout{
-			SiacoinOutput: sces[outputID],
+		element := sces[cs.Index.ID.MinerOutputID(i)]
+		addEvent(types.Hash256(element.ID), element.MaturityHeight, wallet.EventTypeMinerPayout, EventPayout{
+			SiacoinElement: SiacoinOutput{SiacoinElement: element},
 		}, []types.Address{b.MinerPayouts[i].Address})
 	}
 
 	// handle foundation subsidy
-	outputID := cs.Index.ID.FoundationOutputID()
-	sce, ok := sces[outputID]
+	element, ok := sces[cs.Index.ID.FoundationOutputID()]
 	if ok {
-		addEvent(types.Hash256(outputID), cs.MaturityHeight(), &EventFoundationSubsidy{
-			SiacoinOutput: sce,
-		}, []types.Address{cs.FoundationSubsidyAddress})
+		addEvent(types.Hash256(element.ID), element.MaturityHeight, wallet.EventTypeFoundationSubsidy, EventPayout{
+			SiacoinElement: SiacoinOutput{SiacoinElement: element},
+		}, []types.Address{element.SiacoinOutput.Address})
 	}
 
 	return events

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.1
 toolchain go1.23.2
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/ip2location/ip2location-go v8.3.0+incompatible
 	github.com/mattn/go-sqlite3 v1.14.24
 	go.sia.tech/core v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/ip2location/ip2location-go v8.3.0+incompatible h1:QwUE+FlSbo6bjOWZpv2Grb57vJhWYFNPyBj2KCvfWaM=
 github.com/ip2location/ip2location-go v8.3.0+incompatible/go.mod h1:3JUY1TBjTx1GdA7oRT7Zeqfc0bg3lMMuU5lXmzdpuME=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=

--- a/internal/testutil/check.go
+++ b/internal/testutil/check.go
@@ -4,6 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/explored/explorer"
@@ -13,8 +16,8 @@ import (
 func Equal[T any](t *testing.T, desc string, expect, got T) {
 	t.Helper()
 
-	if !reflect.DeepEqual(expect, got) {
-		t.Fatalf("expected %v %s, got %v", expect, desc, got)
+	if !cmp.Equal(expect, got, cmpopts.EquateEmpty(), cmpopts.IgnoreUnexported(consensus.Work{}), cmpopts.IgnoreFields(types.StateElement{}, "MerkleProof")) {
+		t.Fatalf("%s expected != got, diff: %s", desc, cmp.Diff(expect, got))
 	}
 }
 

--- a/persist/sqlite/addresses.go
+++ b/persist/sqlite/addresses.go
@@ -8,87 +8,33 @@ import (
 	"go.sia.tech/explored/explorer"
 )
 
-func scanEvent(tx *txn, s scanner) (ev explorer.Event, eventID int64, err error) {
-	var eventType string
-
-	err = s.Scan(&eventID, decode(&ev.ID), &ev.MaturityHeight, decode(&ev.Timestamp), &ev.Index.Height, decode(&ev.Index.ID), &eventType)
-	if err != nil {
-		return
-	}
-
-	switch eventType {
-	case explorer.EventTypeTransaction:
-		var txnID int64
-		var eventTx explorer.EventTransaction
-		err = tx.QueryRow(`SELECT transaction_id, fee FROM transaction_events WHERE event_id = ?`, eventID).Scan(&txnID, decode(&eventTx.Fee))
-		if err != nil {
-			return explorer.Event{}, 0, fmt.Errorf("failed to fetch transaction ID: %w", err)
-		}
-		txns, err := getTransactions(tx, map[int64]transactionID{0: {dbID: txnID, id: types.TransactionID(ev.ID)}})
-		if err != nil || len(txns) == 0 {
-			return explorer.Event{}, 0, fmt.Errorf("failed to fetch transaction: %w", err)
-		}
-		eventTx.Transaction = txns[0]
-		eventTx.HostAnnouncements = eventTx.Transaction.HostAnnouncements
-		ev.Data = &eventTx
-	case explorer.EventTypeV2Transaction:
-		var txnID int64
-		err = tx.QueryRow(`SELECT transaction_id FROM v2_transaction_events WHERE event_id = ?`, eventID).Scan(&txnID)
-		if err != nil {
-			return explorer.Event{}, 0, fmt.Errorf("failed to fetch v2 transaction ID: %w", err)
-		}
-		txns, err := getV2Transactions(tx, []types.TransactionID{types.TransactionID(ev.ID)})
-		if err != nil || len(txns) == 0 {
-			return explorer.Event{}, 0, fmt.Errorf("failed to fetch v2 transaction: %w", err)
-		}
-		eventTx := explorer.EventV2Transaction(txns[0])
-		ev.Data = &eventTx
-	case explorer.EventTypeContractPayout:
-		var m explorer.EventContractPayout
-		err = tx.QueryRow(`SELECT sce.output_id, sce.leaf_index, sce.maturity_height, sce.address, sce.value, fce.contract_id, fce.leaf_index, fce.filesize, fce.file_merkle_root, fce.window_start, fce.window_end, fce.payout, fce.unlock_hash, fce.revision_number, ev.missed
-FROM contract_payout_events ev
-JOIN siacoin_elements sce ON ev.output_id = sce.id
-JOIN file_contract_elements fce ON ev.contract_id = fce.id
-WHERE ev.event_id = ?`, eventID).Scan(decode(&m.SiacoinOutput.ID), decode(&m.SiacoinOutput.StateElement.LeafIndex), &m.SiacoinOutput.MaturityHeight, decode(&m.SiacoinOutput.SiacoinOutput.Address), decode(&m.SiacoinOutput.SiacoinOutput.Value), decode(&m.FileContract.ID), decode(&m.FileContract.StateElement.LeafIndex), decode(&m.FileContract.FileContract.Filesize), decode(&m.FileContract.FileContract.FileMerkleRoot), decode(&m.FileContract.FileContract.WindowStart), decode(&m.FileContract.FileContract.WindowEnd), decode(&m.FileContract.FileContract.Payout), decode(&m.FileContract.FileContract.UnlockHash), decode(&m.FileContract.FileContract.RevisionNumber), &m.Missed)
-		ev.Data = &m
-	case explorer.EventTypeMinerPayout:
-		var m explorer.EventMinerPayout
-		err = tx.QueryRow(`SELECT sc.output_id, sc.leaf_index, sc.maturity_height, sc.address, sc.value
-FROM siacoin_elements sc
-INNER JOIN miner_payout_events ev ON ev.output_id = sc.id
-WHERE ev.event_id = ?`, eventID).Scan(decode(&m.SiacoinOutput.ID), decode(&m.SiacoinOutput.StateElement.LeafIndex), decode(&m.SiacoinOutput.MaturityHeight), decode(&m.SiacoinOutput.SiacoinOutput.Address), decode(&m.SiacoinOutput.SiacoinOutput.Value))
-		if err != nil {
-			return explorer.Event{}, 0, fmt.Errorf("failed to fetch miner payout event data: %w", err)
-		}
-		ev.Data = &m
-	case explorer.EventTypeFoundationSubsidy:
-		var m explorer.EventFoundationSubsidy
-		err = tx.QueryRow(`SELECT sc.output_id, sc.leaf_index, sc.maturity_height, sc.address, sc.value
-FROM siacoin_elements sc
-INNER JOIN foundation_subsidy_events ev ON ev.output_id = sc.id
-WHERE ev.event_id = ?`, eventID).Scan(decode(&m.SiacoinOutput.ID), decode(&m.SiacoinOutput.StateElement.LeafIndex), decode(&m.SiacoinOutput.MaturityHeight), decode(&m.SiacoinOutput.SiacoinOutput.Address), decode(&m.SiacoinOutput.SiacoinOutput.Value))
-		ev.Data = &m
-	default:
-		return explorer.Event{}, 0, fmt.Errorf("unknown event type: %s", eventType)
-	}
-
-	if err != nil {
-		return explorer.Event{}, 0, fmt.Errorf("failed to fetch transaction event data: %w", err)
-	}
-
-	return
-}
-
 // AddressEvents returns the events of a single address.
 func (s *Store) AddressEvents(address types.Address, offset, limit uint64) (events []explorer.Event, err error) {
 	err = s.transaction(func(tx *txn) error {
-		const query = `SELECT ev.id, ev.event_id, ev.maturity_height, ev.date_created, ev.height, ev.block_id, ev.event_type
-	FROM events ev
-	INNER JOIN event_addresses ea ON ev.id = ea.event_id
-	INNER JOIN address_balance sa ON ea.address_id = sa.id
-	WHERE sa.address = $1
-	ORDER BY ev.maturity_height DESC, ev.id DESC
-	LIMIT $2 OFFSET $3`
+		const query = `
+WITH last_chain_index (height) AS (
+    SELECT MAX(height) FROM blocks
+)
+SELECT
+	ev.id,
+	ev.event_id,
+	ev.maturity_height,
+	ev.date_created,
+	b.height,
+	b.id,
+	CASE
+		WHEN last_chain_index.height < b.height THEN 0
+		ELSE last_chain_index.height - b.height
+	END AS confirmations,
+	ev.event_type
+FROM events ev INDEXED BY events_maturity_height_id_idx -- force the index to prevent temp-btree sorts
+INNER JOIN event_addresses ea ON (ev.id = ea.event_id)
+INNER JOIN address_balance sa ON (ea.address_id = sa.id)
+INNER JOIN blocks b ON (ev.block_id = b.id)
+CROSS JOIN last_chain_index
+WHERE sa.address = $1
+ORDER BY ev.maturity_height DESC, ev.id DESC
+LIMIT $2 OFFSET $3`
 
 		rows, err := tx.Query(query, encode(address), limit, offset)
 		if err != nil {
@@ -101,7 +47,7 @@ func (s *Store) AddressEvents(address types.Address, offset, limit uint64) (even
 			if err != nil {
 				return fmt.Errorf("failed to scan event: %w", err)
 			}
-
+			event.Relevant = []types.Address{address}
 			events = append(events, event)
 		}
 		return rows.Err()

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
 	"reflect"
 	"time"
 
@@ -716,9 +715,6 @@ func addEvents(tx *txn, bid types.BlockID, scDBIds map[types.SiacoinOutputID]int
 		case explorer.EventPayout:
 			_, err = payoutEventStmt.Exec(eventID, scDBIds[types.SiacoinOutputID(event.ID)])
 		case explorer.EventV1ContractResolution:
-			ddd := explorer.DBFileContract{ID: v.Parent.ID, RevisionNumber: v.Parent.RevisionNumber}
-			log.Printf("scDBIDs[%+v] = %v, fcDBIds[%+v] = %d", v.SiacoinElement.ID, scDBIds[v.SiacoinElement.ID], ddd, fcDBIds[ddd])
-
 			_, err = v1ContractResolutionEventStmt.Exec(eventID, scDBIds[v.SiacoinElement.ID], fcDBIds[explorer.DBFileContract{ID: v.Parent.ID, RevisionNumber: v.Parent.RevisionNumber}], v.Missed)
 		case explorer.EventV2ContractResolution:
 			_, err = v2ContractResolutionEventStmt.Exec(eventID, scDBIds[v.SiacoinElement.ID], v2FcDBIds[explorer.DBFileContract{ID: v.Resolution.Parent.ID, RevisionNumber: v.Resolution.Parent.V2FileContract.RevisionNumber}], v.Missed)

--- a/persist/sqlite/events.go
+++ b/persist/sqlite/events.go
@@ -1,0 +1,154 @@
+package sqlite
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/wallet"
+	"go.sia.tech/explored/explorer"
+)
+
+// Events returns the events with the given event IDs. If an event is not found,
+// it is skipped.
+func (s *Store) Events(eventIDs []types.Hash256) (events []explorer.Event, err error) {
+	err = s.transaction(func(tx *txn) error {
+		// sqlite doesn't have easy support for IN clauses, use a statement since
+		// the number of event IDs is likely to be small instead of dynamically
+		// building the query
+		const query = `
+WITH last_chain_index (height) AS (
+    SELECT MAX(height) FROM blocks
+)
+SELECT 
+	ev.id, 
+	ev.event_id, 
+	ev.maturity_height, 
+	ev.date_created, 
+	b.height, 
+	b.id, 
+	CASE 
+		WHEN last_chain_index.height < b.height THEN 0
+		ELSE last_chain_index.height - b.height
+	END AS confirmations,
+	ev.event_type
+FROM events ev
+INNER JOIN event_addresses ea ON (ev.id = ea.event_id)
+INNER JOIN address_balance sa ON (ea.address_id = sa.id)
+INNER JOIN blocks b ON (ev.block_id = b.id)
+CROSS JOIN last_chain_index
+WHERE ev.event_id = $1`
+
+		stmt, err := tx.Prepare(query)
+		if err != nil {
+			return fmt.Errorf("failed to prepare statement: %w", err)
+		}
+		defer stmt.Close()
+
+		events = make([]explorer.Event, 0, len(eventIDs))
+		for _, id := range eventIDs {
+			event, _, err := scanEvent(tx, stmt.QueryRow(encode(id)))
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("failed to query transaction %q: %w", id, err)
+			}
+			events = append(events, event)
+		}
+		return nil
+	})
+	return
+}
+
+func scanEvent(tx *txn, s scanner) (ev explorer.Event, eventID int64, err error) {
+	err = s.Scan(&eventID, decode(&ev.ID), &ev.MaturityHeight, decode(&ev.Timestamp), &ev.Index.Height, decode(&ev.Index.ID), &ev.Confirmations, &ev.Type)
+	if err != nil {
+		return
+	}
+
+	switch ev.Type {
+	case wallet.EventTypeV1Transaction:
+		var txnID int64
+		err = tx.QueryRow(`SELECT transaction_id FROM v1_transaction_events WHERE event_id = ?`, eventID).Scan(&txnID)
+		if err != nil {
+			return explorer.Event{}, 0, fmt.Errorf("failed to fetch v1 transaction ID: %w", err)
+		}
+		txns, err := getTransactions(tx, map[int64]transactionID{0: {dbID: txnID, id: types.TransactionID(ev.ID)}})
+		if err != nil || len(txns) == 0 {
+			return explorer.Event{}, 0, fmt.Errorf("failed to fetch v1 transaction: %w", err)
+		}
+		ev.Data = explorer.EventV1Transaction{
+			Transaction: txns[0],
+		}
+	case wallet.EventTypeV2Transaction:
+		txns, err := getV2Transactions(tx, []types.TransactionID{types.TransactionID(ev.ID)})
+		if err != nil || len(txns) == 0 {
+			return explorer.Event{}, 0, fmt.Errorf("failed to fetch v2 transaction: %w", err)
+		}
+		ev.Data = explorer.EventV2Transaction(txns[0])
+	case wallet.EventTypeV1ContractResolution:
+		var resolution explorer.EventV1ContractResolution
+		fce, sce := &resolution.Parent, &resolution.SiacoinElement
+		err := tx.QueryRow(`SELECT sce.output_id, sce.leaf_index, sce.maturity_height, sce.address, sce.value, fce.contract_id, fce.filesize, fce.file_merkle_root, fce.window_start, fce.window_end, fce.payout, fce.unlock_hash, fce.revision_number, ev.missed
+			FROM v1_contract_resolution_events ev
+			JOIN siacoin_elements sce ON ev.output_id = sce.id
+			JOIN file_contract_elements fce ON ev.parent_id = fce.id
+			WHERE ev.event_id = ?`, eventID).Scan(decode(&sce.ID), decode(&sce.StateElement.LeafIndex), decode(&sce.MaturityHeight), decode(&sce.SiacoinOutput.Address), decode(&sce.SiacoinOutput.Value), decode(&fce.ID), decode(&fce.Filesize), decode(&fce.FileMerkleRoot), decode(&fce.WindowStart), decode(&fce.WindowEnd), decode(&fce.Payout), decode(&fce.UnlockHash), decode(&fce.RevisionNumber), &resolution.Missed)
+		if err != nil {
+			return explorer.Event{}, 0, fmt.Errorf("failed to retrieve v1 resolution event: %w", err)
+		}
+		ev.Data = resolution
+	case wallet.EventTypeV2ContractResolution:
+		var resolution explorer.EventV2ContractResolution
+		var parentContractID types.FileContractID
+		var resolutionTransactionID types.TransactionID
+		sce := &resolution.SiacoinElement
+		err := tx.QueryRow(`SELECT sce.output_id, sce.leaf_index, sce.maturity_height, sce.address, sce.value, rev.contract_id, rev.resolution_transaction_id, ev.missed
+			FROM v2_contract_resolution_events ev
+			JOIN siacoin_elements sce ON ev.output_id = sce.id
+			JOIN v2_file_contract_elements fce ON ev.parent_id = fce.id
+ 			JOIN v2_last_contract_revision rev ON fce.contract_id = rev.contract_id
+			WHERE ev.event_id = ?`, eventID).Scan(decode(&sce.ID), decode(&sce.StateElement.LeafIndex), decode(&sce.MaturityHeight), decode(&sce.SiacoinOutput.Address), decode(&sce.SiacoinOutput.Value), decode(&parentContractID), decode(&resolutionTransactionID), &resolution.Missed)
+		if err != nil {
+			return explorer.Event{}, 0, fmt.Errorf("failed to retrieve v2 resolution event: %w", err)
+		}
+
+		resolutionTxns, err := getV2Transactions(tx, []types.TransactionID{resolutionTransactionID})
+		if err != nil {
+			return explorer.Event{}, 0, fmt.Errorf("failed to get transaction with v2 resolution: %w", err)
+		} else if len(resolutionTxns) == 0 {
+			return explorer.Event{}, 0, fmt.Errorf("v2 resolution transaction not found")
+		}
+		txn := resolutionTxns[0]
+
+		found := false
+		for _, fcr := range txn.FileContractResolutions {
+			if fcr.Parent.ID == parentContractID {
+				found = true
+				resolution.Resolution = fcr
+				break
+			}
+		}
+		if !found {
+			return explorer.Event{}, 0, fmt.Errorf("failed to find resolution in v2 resolution transaction")
+		}
+
+		ev.Data = resolution
+	case wallet.EventTypeSiafundClaim, wallet.EventTypeMinerPayout, wallet.EventTypeFoundationSubsidy:
+		var payout explorer.EventPayout
+		sce := &payout.SiacoinElement
+		err := tx.QueryRow(`SELECT sce.output_id, sce.leaf_index, sce.maturity_height, sce.address, sce.value
+			FROM payout_events ev
+			JOIN siacoin_elements sce ON ev.output_id = sce.id
+			WHERE ev.event_id = ?`, eventID).Scan(decode(&sce.ID), decode(&sce.StateElement.LeafIndex), decode(&sce.MaturityHeight), decode(&sce.SiacoinOutput.Address), decode(&sce.SiacoinOutput.Value))
+		if err != nil {
+			return explorer.Event{}, 0, fmt.Errorf("failed to retrieve payout event: %w", err)
+		}
+		ev.Data = payout
+	default:
+		return explorer.Event{}, 0, fmt.Errorf("unknown event type: %q", ev.Type)
+	}
+
+	return
+}


### PR DESCRIPTION
~~Use the standard event type used in our other apps.  Unfortunately to avoid duplicating queries this requires some conversions from explorer types to core types.  Alternatively, we could just use the enhanced explorer types for the transaction and resolution events which would make things somewhat easier.~~

Use standard event types from used in other apps, but with explorer type versions of the fields rather than the core versions.

Fix https://github.com/SiaFoundation/explored/issues/78