### PR TITLE
Fix host scanning bug

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -67,7 +67,7 @@ type Store interface {
 	SiafundElements(ids []types.SiafundOutputID) (result []SiafundOutput, err error)
 
 	Hosts(pks []types.PublicKey) ([]Host, error)
-	HostsForScanning(maxLastScan, minLastAnnouncement time.Time, offset, limit uint64) ([]Host, error)
+	HostsForScanning(maxLastScan, minLastAnnouncement time.Time, limit uint64) ([]Host, error)
 }
 
 // Explorer implements a Sia explorer.

--- a/explorer/scan.go
+++ b/explorer/scan.go
@@ -248,6 +248,7 @@ func (e *Explorer) fetchHosts(hosts chan Host) {
 		} else if len(batch) < scanBatchSize {
 			exhausted = true
 		}
+		offset += len(batch)
 
 		for _, host := range batch {
 			select {

--- a/persist/sqlite/addresses.go
+++ b/persist/sqlite/addresses.go
@@ -140,9 +140,9 @@ func (st *Store) Hosts(pks []types.PublicKey) (result []explorer.Host, err error
 // HostsForScanning returns hosts ordered by the transaction they were created in.
 // Note that only the PublicKey, NetAddress, and V2NetAddresses fields are
 // populated.
-func (s *Store) HostsForScanning(maxLastScan, minLastAnnouncement time.Time, offset, limit uint64) (result []explorer.Host, err error) {
+func (s *Store) HostsForScanning(maxLastScan, minLastAnnouncement time.Time, limit uint64) (result []explorer.Host, err error) {
 	err = s.transaction(func(tx *txn) error {
-		rows, err := tx.Query(`SELECT public_key, net_address FROM host_info WHERE last_scan <= ? AND last_announcement >= ? ORDER BY last_scan ASC LIMIT ? OFFSET ?`, encode(maxLastScan), encode(minLastAnnouncement), limit, offset)
+		rows, err := tx.Query(`SELECT public_key, net_address FROM host_info WHERE last_scan <= ? AND last_announcement >= ? ORDER BY last_scan ASC LIMIT ?`, encode(maxLastScan), encode(minLastAnnouncement), limit)
 		if err != nil {
 			return err
 		}

--- a/persist/sqlite/consensus_test.go
+++ b/persist/sqlite/consensus_test.go
@@ -1651,7 +1651,7 @@ func TestHostAnnouncement(t *testing.T) {
 	}
 
 	ts := time.Unix(0, 0)
-	hosts, err := db.HostsForScanning(ts, ts, 0, 100)
+	hosts, err := db.HostsForScanning(ts, ts, 100)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fix scanning bug that has affected the mainnet explored node.  We were not incrementing the offset passed to `HostsForScanning` in `fetchHosts`.  On testnets and in tests this wasn't a problem because the number of hosts was fewer than the batch size (`scanBatchSize`), so incrementing the offset wasn't necessary cause it'd only take one loop iteration in `fetchHosts`.  On mainnet this was a problem though so we'd keep scanning the same hosts over and over and never closing the hosts channel so the scans that were completed were never added to the DB.