### PR TITLE
Rationalize search API HTTP error codes and add hosts and v2 contracts to search

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -528,6 +528,13 @@ func TestAPI(t *testing.T) {
 			}
 			testutil.Equal(t, "search type", explorer.SearchTypeContract, resp)
 		}},
+		{"Search host", func(t *testing.T) {
+			resp, err := client.Search(types.Hash256(pk1.PublicKey()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			testutil.Equal(t, "search type", explorer.SearchTypeHost, resp)
+		}},
 		{"Exchange rate", func(t *testing.T) {
 			resp, err := client.ExchangeRate("USD")
 			if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -508,28 +508,43 @@ func TestAPI(t *testing.T) {
 			testutil.CheckFC(t, true, false, false, revFC, resp[0])
 		}},
 		{"Search siacoin", func(t *testing.T) {
-			resp, err := client.Search(types.Hash256(txn1.SiacoinOutputID(0)))
+			resp, err := client.Search(txn1.SiacoinOutputID(0).String())
 			if err != nil {
 				t.Fatal(err)
 			}
 			testutil.Equal(t, "search type", explorer.SearchTypeSiacoinElement, resp)
 		}},
 		{"Search siafund", func(t *testing.T) {
-			resp, err := client.Search(types.Hash256(txn2.SiafundOutputID(1)))
+			resp, err := client.Search(txn2.SiafundOutputID(1).String())
 			if err != nil {
 				t.Fatal(err)
 			}
 			testutil.Equal(t, "search type", explorer.SearchTypeSiafundElement, resp)
 		}},
 		{"Search contract", func(t *testing.T) {
-			resp, err := client.Search(types.Hash256(txn1.FileContractID(0)))
+			resp, err := client.Search(txn1.FileContractID(0).String())
 			if err != nil {
 				t.Fatal(err)
 			}
 			testutil.Equal(t, "search type", explorer.SearchTypeContract, resp)
 		}},
+		{"Search contract prefixed", func(t *testing.T) {
+			resp, err := client.Search("fcid:" + txn1.FileContractID(0).String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			testutil.Equal(t, "search type", explorer.SearchTypeContract, resp)
+		}},
+		{"Search invalid", func(t *testing.T) {
+			if _, err := client.Search(":"); err == nil {
+				t.Fatal("unparsable search should have failed")
+			}
+			if _, err := client.Search("nbcbsfdhjf"); err == nil {
+				t.Fatal("non hex search should have failed")
+			}
+		}},
 		{"Search host", func(t *testing.T) {
-			resp, err := client.Search(types.Hash256(pk1.PublicKey()))
+			resp, err := client.Search(pk1.PublicKey().String())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/api/client.go
+++ b/api/client.go
@@ -274,8 +274,8 @@ func (c *Client) HostMetrics() (resp explorer.HostMetrics, err error) {
 }
 
 // Search returns what type of object an ID is.
-func (c *Client) Search(id types.Hash256) (resp explorer.SearchType, err error) {
-	err = c.c.GET(fmt.Sprintf("/search/%s", id.String()), &resp)
+func (c *Client) Search(id string) (resp explorer.SearchType, err error) {
+	err = c.c.GET(fmt.Sprintf("/search/%s", id), &resp)
 	return
 }
 

--- a/api/server.go
+++ b/api/server.go
@@ -729,6 +729,9 @@ func (s *server) searchIDHandler(jc jape.Context) {
 	if errors.Is(err, explorer.ErrNoSearchResults) {
 		jc.Error(ErrNoSearchResults, http.StatusNotFound)
 		return
+	} else if errors.Is(err, explorer.ErrSearchParse) {
+		jc.Error(err, http.StatusBadRequest)
+		return
 	} else if jc.Check("failed to search ID", err) != nil {
 		return
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -72,7 +71,7 @@ type (
 		V2Contracts(ids []types.FileContractID) (result []explorer.V2FileContract, err error)
 		V2ContractsKey(key types.PublicKey) (result []explorer.V2FileContract, err error)
 		V2ContractRevisions(id types.FileContractID) (result []explorer.V2FileContract, err error)
-		Search(id types.Hash256) (explorer.SearchType, error)
+		Search(id string) (explorer.SearchType, error)
 
 		Hosts(pks []types.PublicKey) ([]explorer.Host, error)
 		QueryHosts(params explorer.HostQuery, sortBy explorer.HostSortColumn, dir explorer.HostSortDir, offset, limit uint64) ([]explorer.Host, error)
@@ -721,21 +720,12 @@ func (s *server) hostsHandler(jc jape.Context) {
 }
 
 func (s *server) searchIDHandler(jc jape.Context) {
-	const idLen = len(types.Hash256{})
-
-	// get everything after separator if there is one
-	split := strings.Split(jc.PathParam("id"), ":")
-	id, err := hex.DecodeString(split[len(split)-1])
-	if err != nil {
-		jc.Error(errors.New("failed to decode hex"), http.StatusBadRequest)
-		return
-	} else if len(id) < idLen {
-		jc.Error(fmt.Errorf("expected length %d, got %d", idLen, len(id)), http.StatusBadRequest)
+	var id string
+	if jc.DecodeParam("id", &id) != nil {
 		return
 	}
 
-	trunc := id[:idLen]
-	result, err := s.e.Search(types.Hash256(trunc))
+	result, err := s.e.Search(id)
 	if errors.Is(err, explorer.ErrNoSearchResults) {
 		jc.Error(ErrNoSearchResults, http.StatusNotFound)
 		return

--- a/api/server.go
+++ b/api/server.go
@@ -721,7 +721,7 @@ func (s *server) hostsHandler(jc jape.Context) {
 }
 
 func (s *server) searchIDHandler(jc jape.Context) {
-	const maxLen = len(types.Hash256{})
+	const idLen = len(types.Hash256{})
 
 	// get everything after separator if there is one
 	split := strings.Split(jc.PathParam("id"), ":")
@@ -729,9 +729,12 @@ func (s *server) searchIDHandler(jc jape.Context) {
 	if err != nil {
 		jc.Error(errors.New("failed to decode hex"), http.StatusBadRequest)
 		return
+	} else if len(id) < idLen {
+		jc.Error(fmt.Errorf("expected length %d, got %d", idLen, len(id)), http.StatusBadRequest)
+		return
 	}
 
-	trunc := id[:maxLen]
+	trunc := id[:idLen]
 	result, err := s.e.Search(types.Hash256(trunc))
 	if err == explorer.ErrNoSearchResults {
 		jc.Error(ErrNoSearchResults, http.StatusNotFound)

--- a/api/server.go
+++ b/api/server.go
@@ -736,7 +736,7 @@ func (s *server) searchIDHandler(jc jape.Context) {
 
 	trunc := id[:idLen]
 	result, err := s.e.Search(types.Hash256(trunc))
-	if err == explorer.ErrNoSearchResults {
+	if errors.Is(err, explorer.ErrNoSearchResults) {
 		jc.Error(ErrNoSearchResults, http.StatusNotFound)
 		return
 	} else if jc.Check("failed to search ID", err) != nil {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -24,6 +24,10 @@ var (
 	// the specified contract ID.
 	ErrContractNotFound = errors.New("contract not found")
 
+	// ErrSearchParse is returned when Search is unable to parse the specified
+	// ID.
+	ErrSearchParse = errors.New("error parsing ID")
+
 	// ErrNoSearchResults is returned when Search is unable to find anything
 	// with the specified ID.
 	ErrNoSearchResults = errors.New("no search results")

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -24,6 +24,10 @@ var (
 	// ErrContractNotFound is returned when ContractRevisions is unable to find
 	// the specified contract ID.
 	ErrContractNotFound = errors.New("contract not found")
+
+	// ErrNoSearchResults is returned when Search is unable to find anything
+	// with the specified ID.
+	ErrNoSearchResults = errors.New("no search results")
 )
 
 // A ChainManager manages the consensus state
@@ -459,5 +463,5 @@ func (e *Explorer) Search(id types.Hash256) (SearchType, error) {
 		return SearchTypeHost, nil
 	}
 
-	return SearchTypeInvalid, errors.New("no such element")
+	return SearchTypeInvalid, ErrNoSearchResults
 }

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -445,5 +445,19 @@ func (e *Explorer) Search(id types.Hash256) (SearchType, error) {
 		return SearchTypeContract, nil
 	}
 
+	v2Contracts, err := e.V2Contracts([]types.FileContractID{types.FileContractID(id)})
+	if err != nil {
+		return SearchTypeInvalid, err
+	} else if len(v2Contracts) > 0 {
+		return SearchTypeV2Contract, nil
+	}
+
+	hosts, err := e.Hosts([]types.PublicKey{types.PublicKey(id)})
+	if err != nil {
+		return SearchTypeInvalid, err
+	} else if len(hosts) > 0 {
+		return SearchTypeHost, nil
+	}
+
 	return SearchTypeInvalid, errors.New("no such element")
 }

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -74,7 +74,7 @@ type Store interface {
 	V2ContractRevisions(id types.FileContractID) (result []V2FileContract, err error)
 	SiacoinElements(ids []types.SiacoinOutputID) (result []SiacoinOutput, err error)
 	SiafundElements(ids []types.SiafundOutputID) (result []SiafundOutput, err error)
-	Search(id types.Hash256) (SearchType, error)
+	Search(id string) (SearchType, error)
 
 	QueryHosts(params HostQuery, sortBy HostSortColumn, dir HostSortDir, offset, limit uint64) ([]Host, error)
 	HostsForScanning(maxLastScan, minLastAnnouncement time.Time, limit uint64) ([]Host, error)
@@ -406,6 +406,6 @@ func (e *Explorer) QueryHosts(params HostQuery, sortBy HostSortColumn, dir HostS
 
 // Search returns the type of an element (siacoin element, siafund element,
 // contract, v2 contract, transaction, v2 transaction, block, or host).
-func (e *Explorer) Search(id types.Hash256) (SearchType, error) {
+func (e *Explorer) Search(id string) (SearchType, error) {
 	return e.s.Search(id)
 }

--- a/explorer/types.go
+++ b/explorer/types.go
@@ -87,9 +87,11 @@ const (
 	SearchTypeBlock SearchType = "block"
 	// SearchTypeTransaction means we found a transaction with the given ID.
 	SearchTypeTransaction SearchType = "transaction"
-	// SearchTypeSiacoinElement means we found a contract with the given ID.
+	// SearchTypeSiacoinElement means we found a siacoin element with the given
+	// ID.
 	SearchTypeSiacoinElement SearchType = "siacoinElement"
-	// SearchTypeSiafundElement means we found a contract with the given ID.
+	// SearchTypeSiafundElement means we found a siafund element with the given
+	// ID.
 	SearchTypeSiafundElement SearchType = "siafundElement"
 	// SearchTypeContract means we found a contract with the given ID.
 	SearchTypeContract SearchType = "contract"

--- a/explorer/types.go
+++ b/explorer/types.go
@@ -87,6 +87,8 @@ const (
 	SearchTypeBlock SearchType = "block"
 	// SearchTypeTransaction means we found a transaction with the given ID.
 	SearchTypeTransaction SearchType = "transaction"
+	// SearchTypeV2Transaction means we found a v2 transaction with the given ID.
+	SearchTypeV2Transaction SearchType = "v2Transaction"
 	// SearchTypeSiacoinElement means we found a siacoin element with the given
 	// ID.
 	SearchTypeSiacoinElement SearchType = "siacoinElement"

--- a/explorer/types.go
+++ b/explorer/types.go
@@ -93,6 +93,10 @@ const (
 	SearchTypeSiafundElement SearchType = "siafundElement"
 	// SearchTypeContract means we found a contract with the given ID.
 	SearchTypeContract SearchType = "contract"
+	// SearchTypeV2Contract means we found a V2 contract with the given ID.
+	SearchTypeV2Contract SearchType = "v2contract"
+	// SearchTypeHost means we found a host with the given pubkey.
+	SearchTypeHost SearchType = "host"
 )
 
 // A ResolutionType represents the type of a v2 file contract resolution.

--- a/persist/sqlite/search.go
+++ b/persist/sqlite/search.go
@@ -1,108 +1,65 @@
 package sqlite
 
 import (
+	"encoding/hex"
+	"errors"
+	"strings"
+
 	"go.sia.tech/core/types"
 	"go.sia.tech/explored/explorer"
 )
 
 // Search implements explorer.Store.
-func (s *Store) Search(id types.Hash256) (explorer.SearchType, error) {
+func (s *Store) Search(input string) (explorer.SearchType, error) {
+	decodeHex := func(input string) ([]byte, error) {
+		// Strip prefix (i.e., "txid:") if present
+		if idx := strings.Index(input, ":"); idx != -1 && len(input) >= idx {
+			input = input[idx+1:]
+		}
+		decoded, err := hex.DecodeString(input)
+		if err != nil {
+			return nil, err
+		}
+		if len(decoded) != len(types.Hash256{}) {
+			return nil, errors.New("should have hex encoded 32 byte input")
+		}
+		return decoded, nil
+	}
+
+	id, err := decodeHex(input)
+	if err != nil {
+		return explorer.SearchTypeInvalid, err
+	}
+
 	var result explorer.SearchType
-	err := s.transaction(func(tx *txn) error {
+	err = s.transaction(func(tx *txn) error {
 		var exists bool
-		encoded := encode(id)
-
-		// Address
-		err := tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM address_balance WHERE address=?)`, encoded).Scan(&exists)
-		if err != nil {
-			return err
-		}
-		if exists {
-			result = explorer.SearchTypeAddress
-			return nil
-		}
-
-		// Block
-		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM blocks WHERE id=?)`, encoded).Scan(&exists)
-		if err != nil {
-			return err
-		}
-		if exists {
-			result = explorer.SearchTypeBlock
-			return nil
+		queries := []struct {
+			query string
+			typ   explorer.SearchType
+		}{
+			{`SELECT EXISTS(SELECT 1 FROM address_balance WHERE address=?)`, explorer.SearchTypeAddress},
+			{`SELECT EXISTS(SELECT 1 FROM blocks WHERE id=?)`, explorer.SearchTypeBlock},
+			{`SELECT EXISTS(SELECT 1 FROM transactions WHERE transaction_id=?)`, explorer.SearchTypeTransaction},
+			{`SELECT EXISTS(SELECT 1 FROM v2_transactions WHERE transaction_id=?)`, explorer.SearchTypeV2Transaction},
+			{`SELECT EXISTS(SELECT 1 FROM siacoin_elements WHERE output_id=?)`, explorer.SearchTypeSiacoinElement},
+			{`SELECT EXISTS(SELECT 1 FROM siafund_elements WHERE output_id=?)`, explorer.SearchTypeSiafundElement},
+			{`SELECT EXISTS(SELECT 1 FROM last_contract_revision WHERE contract_id=?)`, explorer.SearchTypeContract},
+			{`SELECT EXISTS(SELECT 1 FROM v2_last_contract_revision WHERE contract_id=?)`, explorer.SearchTypeV2Contract},
+			{`SELECT EXISTS(SELECT 1 FROM host_info WHERE public_key=?)`, explorer.SearchTypeHost},
 		}
 
-		// Transaction
-		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM transactions WHERE transaction_id=?)`, encoded).Scan(&exists)
-		if err != nil {
-			return err
+		for _, q := range queries {
+			err := tx.QueryRow(q.query, id).Scan(&exists)
+			if err != nil {
+				return err
+			}
+			if exists {
+				result = q.typ
+				return nil
+			}
 		}
-		if exists {
-			result = explorer.SearchTypeTransaction
-			return nil
-		}
-
-		// V2 transaction
-		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM v2_transactions WHERE transaction_id=?)`, encoded).Scan(&exists)
-		if err != nil {
-			return err
-		}
-		if exists {
-			result = explorer.SearchTypeV2Transaction
-			return nil
-		}
-
-		// Siacoin element
-		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM siacoin_elements WHERE output_id=?)`, encoded).Scan(&exists)
-		if err != nil {
-			return err
-		}
-		if exists {
-			result = explorer.SearchTypeSiacoinElement
-			return nil
-		}
-
-		// Siafund element
-		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM siafund_elements WHERE output_id=?)`, encoded).Scan(&exists)
-		if err != nil {
-			return err
-		}
-		if exists {
-			result = explorer.SearchTypeSiafundElement
-			return nil
-		}
-
-		// File contract
-		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM last_contract_revision WHERE contract_id=?)`, encoded).Scan(&exists)
-		if err != nil {
-			return err
-		}
-		if exists {
-			result = explorer.SearchTypeContract
-			return nil
-		}
-
-		// V2 file contract
-		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM v2_last_contract_revision WHERE contract_id=?)`, encoded).Scan(&exists)
-		if err != nil {
-			return err
-		}
-		if exists {
-			result = explorer.SearchTypeV2Contract
-			return nil
-		}
-
-		// Host
-		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM host_info WHERE public_key=?)`, encoded).Scan(&exists)
-		if err != nil {
-			return err
-		}
-		if exists {
-			result = explorer.SearchTypeHost
-			return nil
-		}
-
-		return nil
+		return explorer.ErrNoSearchResults
 	})
 	if err != nil {
 		return explorer.SearchTypeInvalid, err

--- a/persist/sqlite/search.go
+++ b/persist/sqlite/search.go
@@ -1,0 +1,111 @@
+package sqlite
+
+import (
+	"go.sia.tech/core/types"
+	"go.sia.tech/explored/explorer"
+)
+
+// Search implements explorer.Store.
+func (s *Store) Search(id types.Hash256) (explorer.SearchType, error) {
+	var result explorer.SearchType
+	err := s.transaction(func(tx *txn) error {
+		var exists bool
+		encoded := encode(id)
+
+		// Address
+		err := tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM address_balance WHERE address=?)`, encoded).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			result = explorer.SearchTypeAddress
+			return nil
+		}
+
+		// Block
+		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM blocks WHERE id=?)`, encoded).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			result = explorer.SearchTypeBlock
+			return nil
+		}
+
+		// Transaction
+		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM transactions WHERE transaction_id=?)`, encoded).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			result = explorer.SearchTypeTransaction
+			return nil
+		}
+
+		// V2 transaction
+		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM v2_transactions WHERE transaction_id=?)`, encoded).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			result = explorer.SearchTypeV2Transaction
+			return nil
+		}
+
+		// Siacoin element
+		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM siacoin_elements WHERE output_id=?)`, encoded).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			result = explorer.SearchTypeSiacoinElement
+			return nil
+		}
+
+		// Siafund element
+		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM siafund_elements WHERE output_id=?)`, encoded).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			result = explorer.SearchTypeSiafundElement
+			return nil
+		}
+
+		// File contract
+		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM last_contract_revision WHERE contract_id=?)`, encoded).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			result = explorer.SearchTypeContract
+			return nil
+		}
+
+		// V2 file contract
+		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM v2_last_contract_revision WHERE contract_id=?)`, encoded).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			result = explorer.SearchTypeV2Contract
+			return nil
+		}
+
+		// Host
+		err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM host_info WHERE public_key=?)`, encoded).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			result = explorer.SearchTypeHost
+			return nil
+		}
+
+		return nil
+	})
+	if err != nil {
+		return explorer.SearchTypeInvalid, err
+	}
+	return result, nil
+}

--- a/persist/sqlite/search.go
+++ b/persist/sqlite/search.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"strings"
 
 	"go.sia.tech/core/types"
@@ -20,15 +21,17 @@ func (s *Store) Search(input string) (explorer.SearchType, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(decoded) != len(types.Hash256{}) {
+
+		const idLen = len(types.Hash256{})
+		if len(decoded) < len(types.Hash256{}) {
 			return nil, errors.New("should have hex encoded 32 byte input")
 		}
-		return decoded, nil
+		return decoded[:idLen], nil
 	}
 
 	id, err := decodeHex(input)
 	if err != nil {
-		return explorer.SearchTypeInvalid, err
+		return explorer.SearchTypeInvalid, fmt.Errorf("%w: %w", explorer.ErrSearchParse, err)
 	}
 
 	var result explorer.SearchType

--- a/persist/sqlite/v2consensus_test.go
+++ b/persist/sqlite/v2consensus_test.go
@@ -644,8 +644,11 @@ func TestV2FileContractRevert(t *testing.T) {
 	}
 
 	{
-		_, err := db.V2Contracts([]types.FileContractID{txn1.V2FileContractID(txn1.ID(), 0)})
-		if err == nil {
+		fcs, err := db.V2Contracts([]types.FileContractID{txn1.V2FileContractID(txn1.ID(), 0)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fcs) > 0 {
 			t.Fatal("contract should not exist")
 		}
 	}

--- a/persist/sqlite/v2contracts.go
+++ b/persist/sqlite/v2contracts.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"database/sql"
 	"fmt"
 
 	"go.sia.tech/core/types"
@@ -41,10 +42,11 @@ WHERE rev.contract_id = ?
 
 		for _, id := range ids {
 			fc, err := scanV2FileContract(stmt.QueryRow(encode(id)))
-			if err != nil {
+			if err != nil && err != sql.ErrNoRows {
 				return fmt.Errorf("failed to scan file contract: %w", err)
+			} else if err == nil {
+				result = append(result, fc)
 			}
-			result = append(result, fc)
 		}
 
 		return nil

--- a/persist/sqlite/v2contracts.go
+++ b/persist/sqlite/v2contracts.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"go.sia.tech/core/types"
@@ -42,7 +43,7 @@ WHERE rev.contract_id = ?
 
 		for _, id := range ids {
 			fc, err := scanV2FileContract(stmt.QueryRow(encode(id)))
-			if err != nil && err != sql.ErrNoRows {
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				return fmt.Errorf("failed to scan file contract: %w", err)
 			} else if err == nil {
 				result = append(result, fc)


### PR DESCRIPTION
Allow the search endpoint to see if a v2 contract with the specified ID or a host with the specified pubkey exists.  Ed25519 pubkeys and Hash256 values are both 32 bytes and we already strip prefixes on /search/:id so this works out.

Also, we now use errors that make more sense on the search endpoint.  Previously we would just 500 on all errors.  Now:
- If we get a malformed ID, return 400
- If we get an ID that we cannot find in the DB, return 404
- If we get an error in searching the DB, return 500
- Else return 200 and the search result