### PR TITLE
Use standard exchange rate route

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -292,6 +292,6 @@ func (c *Client) HostsList(params explorer.HostQuery, sortBy explorer.HostSortCo
 
 // ExchangeRate returns the value of 1 SC in the specified currency.
 func (c *Client) ExchangeRate(currency string) (resp float64, err error) {
-	err = c.c.GET(fmt.Sprintf("/exchangerate?currency=%s", currency), &resp)
+	err = c.c.GET(fmt.Sprintf("/exchange-rate/siacoin/%s", currency), &resp)
 	return
 }

--- a/api/server.go
+++ b/api/server.go
@@ -740,7 +740,7 @@ func (s *server) searchIDHandler(jc jape.Context) {
 
 func (s *server) exchangeRateHandler(jc jape.Context) {
 	var currency string
-	if jc.DecodeForm("currency", &currency) != nil {
+	if jc.DecodeParam("currency", &currency) != nil {
 		return
 	}
 	if currency == "" {
@@ -824,6 +824,6 @@ func NewServer(e Explorer, cm ChainManager, s Syncer, ex exchangerates.Source) h
 
 		"GET    /search/:id": srv.searchIDHandler,
 
-		"GET    /exchangerate": srv.exchangeRateHandler,
+		"GET    /exchange-rate/siacoin/:currency": srv.exchangeRateHandler,
 	})
 }


### PR DESCRIPTION
Use the `/exchange-rate/siacoin/:currency` format used in our other apps instead of `/exchangerates?currency=`.