### PR TITLE
Add optional CoinGecko pro support

### DIFF
--- a/cmd/explored/main.go
+++ b/cmd/explored/main.go
@@ -272,8 +272,13 @@ func runRootCmd(ctx context.Context, log *zap.Logger) error {
 		exchangerates.CurrencyEUR: exchangerates.KrakenPairSiacoinEUR,
 		exchangerates.CurrencyBTC: exchangerates.KrakenPairSiacoinBTC,
 	}, cfg.ExchangeRates.Refresh))
-	if apiKey := os.Getenv("COINGECKO_API_KEY"); apiKey != "" {
-		sources = append(sources, exchangerates.NewCoinGecko(apiKey, map[string]string{
+
+	coinGeckoPro, coinGeckoAPIKey := false, os.Getenv("COINGECKO_DEMO_API_KEY")
+	if coinGeckoAPIKey == "" {
+		coinGeckoPro, coinGeckoAPIKey = true, os.Getenv("COINGECKO_PRO_API_KEY")
+	}
+	if coinGeckoAPIKey != "" {
+		sources = append(sources, exchangerates.NewCoinGecko(coinGeckoPro, coinGeckoAPIKey, map[string]string{
 			exchangerates.CurrencyUSD: exchangerates.CoinGeckoCurrencyUSD,
 			exchangerates.CurrencyEUR: exchangerates.CoinGeckoCurrencyEUR,
 			exchangerates.CurrencyCAD: exchangerates.CoinGeckoCurrencyCAD,


### PR DESCRIPTION
Fix https://github.com/SiaFoundation/explored/issues/166

Allow users to provide either `COINGECKO_DEMO_API_KEY` or `COINGECKO_PRO_API_KEY` depending on which API they want to use.