### PR TITLE
Use median instead of mean when calculating host metrics

### DIFF
--- a/persist/sqlite/metrics.go
+++ b/persist/sqlite/metrics.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"go.sia.tech/core/types"
@@ -22,6 +23,32 @@ func (s *Store) Metrics(id types.BlockID) (result explorer.Metrics, err error) {
 
 // HostMetrics implements explorer.Store
 func (s *Store) HostMetrics() (result explorer.HostMetrics, err error) {
+	medianUint64 := func(x []uint64) uint64 {
+		if len(x) == 0 {
+			return 0
+		}
+
+		slices.Sort(x)
+		if len(x)%2 == 1 {
+			return x[len(x)/2]
+		}
+		return (x[(len(x)/2)-1] + x[(len(x)/2)]) / 2
+	}
+
+	medianCurrency := func(x []types.Currency) types.Currency {
+		if len(x) == 0 {
+			return types.ZeroCurrency
+		}
+
+		slices.SortFunc(x, func(a, b types.Currency) int {
+			return a.Cmp(b)
+		})
+		if len(x)%2 == 1 {
+			return x[len(x)/2]
+		}
+		return (x[(len(x)/2)-1].Add(x[(len(x) / 2)])).Div64(2)
+	}
+
 	err = s.transaction(func(tx *txn) error {
 		rows, err := tx.Query(`SELECT settings_max_download_batch_size,settings_max_duration,settings_max_revise_batch_size,settings_remaining_storage,settings_sector_size,settings_total_storage,settings_window_size,settings_collateral,settings_max_collateral,settings_base_rpc_price,settings_contract_price,settings_download_bandwidth_price,settings_sector_access_price,settings_storage_price,settings_upload_bandwidth_price,settings_ephemeral_account_expiry,settings_max_ephemeral_account_balance,settings_revision_number,price_table_validity,price_table_host_block_height,price_table_update_price_table_cost,price_table_account_balance_cost,price_table_fund_account_cost,price_table_latest_revision_cost,price_table_subscription_memory_cost,price_table_subscription_notification_cost,price_table_init_base_cost,price_table_memory_time_cost,price_table_download_bandwidth_cost,price_table_upload_bandwidth_cost,price_table_drop_sectors_base_cost,price_table_drop_sectors_unit_cost,price_table_has_sector_base_cost,price_table_read_base_cost,price_table_read_length_cost,price_table_renew_contract_cost,price_table_revision_base_cost,price_table_swap_sector_base_cost,price_table_write_base_cost,price_table_write_length_cost,price_table_write_store_cost,price_table_txn_fee_min_recommended,price_table_txn_fee_max_recommended,price_table_contract_price,price_table_collateral_cost,price_table_max_collateral,price_table_max_duration,price_table_window_size,price_table_registry_entries_left,price_table_registry_entries_total FROM host_info WHERE last_scan_successful = 1`)
 		if err != nil {
@@ -30,6 +57,9 @@ func (s *Store) HostMetrics() (result explorer.HostMetrics, err error) {
 		defer rows.Close()
 
 		var count uint64
+
+		var settingsMaxDownloadBatchSize, settingsMaxDuration, settingsMaxReviseBatchSize, settingsRemainingStorage, settingsSectorSize, settingsTotalStorage, settingsWindowSize, settingsRevisionNumber, priceTableHostBlockHeight, priceTableMaxDuration, priceTableWindowSize, priceTableRegistryEntriesLeft, priceTableRegistryEntriesTotal, settingsEphemeralAccountExpiry, priceTableValidity []uint64
+		var settingsCollateral, settingsMaxCollateral, settingsBaseRPCPrice, settingsContractPrice, settingsDownloadBandwidthPrice, settingsSectorAccessPrice, settingsStoragePrice, settingsUploadBandwidthPrice, settingsMaxEphemeralAccountBalance, priceTableUpdatePriceTableCost, priceTableAccountBalanceCost, priceTableFundAccountCost, priceTableLatestRevisionCost, priceTableSubscriptionMemoryCost, priceTableSubscriptionNotificationCost, priceTableInitBaseCost, priceTableMemoryTimeCost, priceTableDownloadBandwidthCost, priceTableUploadBandwidthCost, priceTableDropSectorsBaseCost, priceTableDropSectorsUnitCost, priceTableHasSectorBaseCost, priceTableReadBaseCost, priceTableReadLengthCost, priceTableRenewContractCost, priceTableRevisionBaseCost, priceTableSwapSectorBaseCost, priceTableWriteBaseCost, priceTableWriteLengthCost, priceTableWriteStoreCost, priceTableTxnFeeMinRecommended, priceTableTxnFeeMaxRecommended, priceTableContractPrice, priceTableCollateralCost, priceTableMaxCollateral []types.Currency
 		for rows.Next() {
 			var host explorer.Host
 			if err := rows.Scan(decode(&host.Settings.MaxDownloadBatchSize), decode(&host.Settings.MaxDuration), decode(&host.Settings.MaxReviseBatchSize), decode(&host.Settings.RemainingStorage), decode(&host.Settings.SectorSize), decode(&host.Settings.TotalStorage), decode(&host.Settings.WindowSize), decode(&host.Settings.Collateral), decode(&host.Settings.MaxCollateral), decode(&host.Settings.BaseRPCPrice), decode(&host.Settings.ContractPrice), decode(&host.Settings.DownloadBandwidthPrice), decode(&host.Settings.SectorAccessPrice), decode(&host.Settings.StoragePrice), decode(&host.Settings.UploadBandwidthPrice), decode(&host.Settings.EphemeralAccountExpiry), decode(&host.Settings.MaxEphemeralAccountBalance), decode(&host.Settings.RevisionNumber), decode(&host.PriceTable.Validity), decode(&host.PriceTable.HostBlockHeight), decode(&host.PriceTable.UpdatePriceTableCost), decode(&host.PriceTable.AccountBalanceCost), decode(&host.PriceTable.FundAccountCost), decode(&host.PriceTable.LatestRevisionCost), decode(&host.PriceTable.SubscriptionMemoryCost), decode(&host.PriceTable.SubscriptionNotificationCost), decode(&host.PriceTable.InitBaseCost), decode(&host.PriceTable.MemoryTimeCost), decode(&host.PriceTable.DownloadBandwidthCost), decode(&host.PriceTable.UploadBandwidthCost), decode(&host.PriceTable.DropSectorsBaseCost), decode(&host.PriceTable.DropSectorsUnitCost), decode(&host.PriceTable.HasSectorBaseCost), decode(&host.PriceTable.ReadBaseCost), decode(&host.PriceTable.ReadLengthCost), decode(&host.PriceTable.RenewContractCost), decode(&host.PriceTable.RevisionBaseCost), decode(&host.PriceTable.SwapSectorBaseCost), decode(&host.PriceTable.WriteBaseCost), decode(&host.PriceTable.WriteLengthCost), decode(&host.PriceTable.WriteStoreCost), decode(&host.PriceTable.TxnFeeMinRecommended), decode(&host.PriceTable.TxnFeeMaxRecommended), decode(&host.PriceTable.ContractPrice), decode(&host.PriceTable.CollateralCost), decode(&host.PriceTable.MaxCollateral), decode(&host.PriceTable.MaxDuration), decode(&host.PriceTable.WindowSize), decode(&host.PriceTable.RegistryEntriesLeft), decode(&host.PriceTable.RegistryEntriesTotal)); err != nil {
@@ -39,57 +69,57 @@ func (s *Store) HostMetrics() (result explorer.HostMetrics, err error) {
 			result.TotalStorage += host.Settings.TotalStorage
 			result.RemainingStorage += host.Settings.RemainingStorage
 
-			result.Settings.MaxDownloadBatchSize += host.Settings.MaxDownloadBatchSize
-			result.Settings.MaxDuration += host.Settings.MaxDuration
-			result.Settings.MaxReviseBatchSize += host.Settings.MaxReviseBatchSize
-			result.Settings.RemainingStorage += host.Settings.RemainingStorage
-			result.Settings.SectorSize += host.Settings.SectorSize
-			result.Settings.TotalStorage += host.Settings.TotalStorage
-			result.Settings.WindowSize += host.Settings.WindowSize
-			result.Settings.Collateral = result.Settings.Collateral.Add(host.Settings.Collateral)
-			result.Settings.MaxCollateral = result.Settings.MaxCollateral.Add(host.Settings.MaxCollateral)
-			result.Settings.BaseRPCPrice = result.Settings.BaseRPCPrice.Add(host.Settings.BaseRPCPrice)
-			result.Settings.ContractPrice = result.Settings.ContractPrice.Add(host.Settings.ContractPrice)
-			result.Settings.DownloadBandwidthPrice = result.Settings.DownloadBandwidthPrice.Add(host.Settings.DownloadBandwidthPrice)
-			result.Settings.SectorAccessPrice = result.Settings.SectorAccessPrice.Add(host.Settings.SectorAccessPrice)
-			result.Settings.StoragePrice = result.Settings.StoragePrice.Add(host.Settings.StoragePrice)
-			result.Settings.UploadBandwidthPrice = result.Settings.UploadBandwidthPrice.Add(host.Settings.UploadBandwidthPrice)
-			result.Settings.EphemeralAccountExpiry += host.Settings.EphemeralAccountExpiry
-			result.Settings.MaxEphemeralAccountBalance = result.Settings.MaxEphemeralAccountBalance.Add(host.Settings.MaxEphemeralAccountBalance)
-			result.Settings.RevisionNumber += host.Settings.RevisionNumber
+			settingsMaxDownloadBatchSize = append(settingsMaxDownloadBatchSize, host.Settings.MaxDownloadBatchSize)
+			settingsMaxDuration = append(settingsMaxDuration, host.Settings.MaxDuration)
+			settingsMaxReviseBatchSize = append(settingsMaxReviseBatchSize, host.Settings.MaxReviseBatchSize)
+			settingsRemainingStorage = append(settingsRemainingStorage, host.Settings.RemainingStorage)
+			settingsSectorSize = append(settingsSectorSize, host.Settings.SectorSize)
+			settingsTotalStorage = append(settingsTotalStorage, host.Settings.TotalStorage)
+			settingsWindowSize = append(settingsWindowSize, host.Settings.WindowSize)
+			settingsCollateral = append(settingsCollateral, host.Settings.Collateral)
+			settingsMaxCollateral = append(settingsMaxCollateral, host.Settings.MaxCollateral)
+			settingsBaseRPCPrice = append(settingsBaseRPCPrice, host.Settings.BaseRPCPrice)
+			settingsContractPrice = append(settingsContractPrice, host.Settings.ContractPrice)
+			settingsDownloadBandwidthPrice = append(settingsDownloadBandwidthPrice, host.Settings.DownloadBandwidthPrice)
+			settingsSectorAccessPrice = append(settingsSectorAccessPrice, host.Settings.SectorAccessPrice)
+			settingsStoragePrice = append(settingsStoragePrice, host.Settings.StoragePrice)
+			settingsUploadBandwidthPrice = append(settingsUploadBandwidthPrice, host.Settings.UploadBandwidthPrice)
+			settingsEphemeralAccountExpiry = append(settingsEphemeralAccountExpiry, uint64(host.Settings.EphemeralAccountExpiry))
+			settingsMaxEphemeralAccountBalance = append(settingsMaxEphemeralAccountBalance, host.Settings.MaxEphemeralAccountBalance)
+			settingsRevisionNumber = append(settingsRevisionNumber, host.Settings.RevisionNumber)
 
-			result.PriceTable.Validity += host.PriceTable.Validity
-			result.PriceTable.HostBlockHeight += host.PriceTable.HostBlockHeight
-			result.PriceTable.UpdatePriceTableCost = result.PriceTable.UpdatePriceTableCost.Add(host.PriceTable.UpdatePriceTableCost)
-			result.PriceTable.AccountBalanceCost = result.PriceTable.AccountBalanceCost.Add(host.PriceTable.AccountBalanceCost)
-			result.PriceTable.FundAccountCost = result.PriceTable.FundAccountCost.Add(host.PriceTable.FundAccountCost)
-			result.PriceTable.LatestRevisionCost = result.PriceTable.LatestRevisionCost.Add(host.PriceTable.LatestRevisionCost)
-			result.PriceTable.SubscriptionMemoryCost = result.PriceTable.SubscriptionMemoryCost.Add(host.PriceTable.SubscriptionMemoryCost)
-			result.PriceTable.SubscriptionNotificationCost = result.PriceTable.SubscriptionNotificationCost.Add(host.PriceTable.SubscriptionNotificationCost)
-			result.PriceTable.InitBaseCost = result.PriceTable.InitBaseCost.Add(host.PriceTable.InitBaseCost)
-			result.PriceTable.MemoryTimeCost = result.PriceTable.MemoryTimeCost.Add(host.PriceTable.MemoryTimeCost)
-			result.PriceTable.DownloadBandwidthCost = result.PriceTable.DownloadBandwidthCost.Add(host.PriceTable.DownloadBandwidthCost)
-			result.PriceTable.UploadBandwidthCost = result.PriceTable.UploadBandwidthCost.Add(host.PriceTable.UploadBandwidthCost)
-			result.PriceTable.DropSectorsBaseCost = result.PriceTable.DropSectorsBaseCost.Add(host.PriceTable.DropSectorsBaseCost)
-			result.PriceTable.DropSectorsUnitCost = result.PriceTable.DropSectorsUnitCost.Add(host.PriceTable.DropSectorsUnitCost)
-			result.PriceTable.HasSectorBaseCost = result.PriceTable.HasSectorBaseCost.Add(host.PriceTable.HasSectorBaseCost)
-			result.PriceTable.ReadBaseCost = result.PriceTable.ReadBaseCost.Add(host.PriceTable.ReadBaseCost)
-			result.PriceTable.ReadLengthCost = result.PriceTable.ReadLengthCost.Add(host.PriceTable.ReadLengthCost)
-			result.PriceTable.RenewContractCost = result.PriceTable.RenewContractCost.Add(host.PriceTable.RenewContractCost)
-			result.PriceTable.RevisionBaseCost = result.PriceTable.RevisionBaseCost.Add(host.PriceTable.RevisionBaseCost)
-			result.PriceTable.SwapSectorBaseCost = result.PriceTable.SwapSectorBaseCost.Add(host.PriceTable.SwapSectorBaseCost)
-			result.PriceTable.WriteBaseCost = result.PriceTable.WriteBaseCost.Add(host.PriceTable.WriteBaseCost)
-			result.PriceTable.WriteLengthCost = result.PriceTable.WriteLengthCost.Add(host.PriceTable.WriteLengthCost)
-			result.PriceTable.WriteStoreCost = result.PriceTable.WriteStoreCost.Add(host.PriceTable.WriteStoreCost)
-			result.PriceTable.TxnFeeMinRecommended = result.PriceTable.TxnFeeMinRecommended.Add(host.PriceTable.TxnFeeMinRecommended)
-			result.PriceTable.TxnFeeMaxRecommended = result.PriceTable.TxnFeeMaxRecommended.Add(host.PriceTable.TxnFeeMaxRecommended)
-			result.PriceTable.ContractPrice = result.PriceTable.ContractPrice.Add(host.PriceTable.ContractPrice)
-			result.PriceTable.CollateralCost = result.PriceTable.CollateralCost.Add(host.PriceTable.CollateralCost)
-			result.PriceTable.MaxCollateral = result.PriceTable.MaxCollateral.Add(host.PriceTable.MaxCollateral)
-			result.PriceTable.MaxDuration += host.PriceTable.MaxDuration
-			result.PriceTable.WindowSize += host.PriceTable.WindowSize
-			result.PriceTable.RegistryEntriesLeft += host.PriceTable.RegistryEntriesLeft
-			result.PriceTable.RegistryEntriesTotal += host.PriceTable.RegistryEntriesTotal
+			priceTableValidity = append(priceTableValidity, uint64(host.PriceTable.Validity))
+			priceTableHostBlockHeight = append(priceTableHostBlockHeight, host.PriceTable.HostBlockHeight)
+			priceTableUpdatePriceTableCost = append(priceTableUpdatePriceTableCost, host.PriceTable.UpdatePriceTableCost)
+			priceTableAccountBalanceCost = append(priceTableAccountBalanceCost, result.PriceTable.AccountBalanceCost)
+			priceTableFundAccountCost = append(priceTableFundAccountCost, result.PriceTable.FundAccountCost)
+			priceTableLatestRevisionCost = append(priceTableLatestRevisionCost, result.PriceTable.LatestRevisionCost)
+			priceTableSubscriptionMemoryCost = append(priceTableSubscriptionMemoryCost, result.PriceTable.SubscriptionMemoryCost)
+			priceTableSubscriptionNotificationCost = append(priceTableSubscriptionNotificationCost, result.PriceTable.SubscriptionNotificationCost)
+			priceTableInitBaseCost = append(priceTableInitBaseCost, result.PriceTable.InitBaseCost)
+			priceTableMemoryTimeCost = append(priceTableMemoryTimeCost, result.PriceTable.MemoryTimeCost)
+			priceTableDownloadBandwidthCost = append(priceTableDownloadBandwidthCost, result.PriceTable.DownloadBandwidthCost)
+			priceTableUploadBandwidthCost = append(priceTableUploadBandwidthCost, result.PriceTable.UploadBandwidthCost)
+			priceTableDropSectorsBaseCost = append(priceTableDropSectorsBaseCost, result.PriceTable.DropSectorsBaseCost)
+			priceTableDropSectorsUnitCost = append(priceTableDropSectorsUnitCost, result.PriceTable.DropSectorsUnitCost)
+			priceTableHasSectorBaseCost = append(priceTableHasSectorBaseCost, result.PriceTable.HasSectorBaseCost)
+			priceTableReadBaseCost = append(priceTableReadBaseCost, result.PriceTable.ReadBaseCost)
+			priceTableReadLengthCost = append(priceTableReadLengthCost, result.PriceTable.ReadLengthCost)
+			priceTableRenewContractCost = append(priceTableRenewContractCost, result.PriceTable.RenewContractCost)
+			priceTableRevisionBaseCost = append(priceTableRevisionBaseCost, result.PriceTable.RevisionBaseCost)
+			priceTableSwapSectorBaseCost = append(priceTableSwapSectorBaseCost, result.PriceTable.SwapSectorBaseCost)
+			priceTableWriteBaseCost = append(priceTableWriteBaseCost, result.PriceTable.WriteBaseCost)
+			priceTableWriteLengthCost = append(priceTableWriteLengthCost, result.PriceTable.WriteLengthCost)
+			priceTableWriteStoreCost = append(priceTableWriteStoreCost, result.PriceTable.WriteStoreCost)
+			priceTableTxnFeeMinRecommended = append(priceTableTxnFeeMinRecommended, result.PriceTable.TxnFeeMinRecommended)
+			priceTableTxnFeeMaxRecommended = append(priceTableTxnFeeMaxRecommended, result.PriceTable.TxnFeeMaxRecommended)
+			priceTableContractPrice = append(priceTableContractPrice, result.PriceTable.ContractPrice)
+			priceTableCollateralCost = append(priceTableCollateralCost, result.PriceTable.CollateralCost)
+			priceTableMaxCollateral = append(priceTableMaxCollateral, result.PriceTable.MaxCollateral)
+			priceTableMaxDuration = append(priceTableMaxDuration, host.PriceTable.MaxDuration)
+			priceTableWindowSize = append(priceTableWindowSize, host.PriceTable.WindowSize)
+			priceTableRegistryEntriesLeft = append(priceTableRegistryEntriesLeft, host.PriceTable.RegistryEntriesLeft)
+			priceTableRegistryEntriesTotal = append(priceTableRegistryEntriesTotal, host.PriceTable.RegistryEntriesTotal)
 
 			count++
 		}
@@ -97,57 +127,57 @@ func (s *Store) HostMetrics() (result explorer.HostMetrics, err error) {
 		if count > 0 {
 			result.ActiveHosts = count
 
-			result.Settings.MaxDownloadBatchSize /= count
-			result.Settings.MaxDuration /= count
-			result.Settings.MaxReviseBatchSize /= count
-			result.Settings.RemainingStorage /= count
-			result.Settings.SectorSize /= count
-			result.Settings.TotalStorage /= count
-			result.Settings.WindowSize /= count
-			result.Settings.Collateral = result.Settings.Collateral.Div64(count)
-			result.Settings.MaxCollateral = result.Settings.MaxCollateral.Div64(count)
-			result.Settings.BaseRPCPrice = result.Settings.BaseRPCPrice.Div64(count)
-			result.Settings.ContractPrice = result.Settings.ContractPrice.Div64(count)
-			result.Settings.DownloadBandwidthPrice = result.Settings.DownloadBandwidthPrice.Div64(count)
-			result.Settings.SectorAccessPrice = result.Settings.SectorAccessPrice.Div64(count)
-			result.Settings.StoragePrice = result.Settings.StoragePrice.Div64(count)
-			result.Settings.UploadBandwidthPrice = result.Settings.UploadBandwidthPrice.Div64(count)
-			result.Settings.EphemeralAccountExpiry /= time.Duration(count)
-			result.Settings.MaxEphemeralAccountBalance = result.Settings.MaxEphemeralAccountBalance.Div64(count)
-			result.Settings.RevisionNumber /= count
+			result.Settings.MaxDownloadBatchSize = medianUint64(settingsMaxDownloadBatchSize)
+			result.Settings.MaxDuration = medianUint64(settingsMaxDuration)
+			result.Settings.MaxReviseBatchSize = medianUint64(settingsMaxReviseBatchSize)
+			result.Settings.RemainingStorage = medianUint64(settingsRemainingStorage)
+			result.Settings.SectorSize = medianUint64(settingsSectorSize)
+			result.Settings.TotalStorage = medianUint64(settingsTotalStorage)
+			result.Settings.WindowSize = medianUint64(settingsWindowSize)
+			result.Settings.Collateral = medianCurrency(settingsCollateral)
+			result.Settings.MaxCollateral = medianCurrency(settingsMaxCollateral)
+			result.Settings.BaseRPCPrice = medianCurrency(settingsBaseRPCPrice)
+			result.Settings.ContractPrice = medianCurrency(settingsContractPrice)
+			result.Settings.DownloadBandwidthPrice = medianCurrency(settingsDownloadBandwidthPrice)
+			result.Settings.SectorAccessPrice = medianCurrency(settingsSectorAccessPrice)
+			result.Settings.StoragePrice = medianCurrency(settingsStoragePrice)
+			result.Settings.UploadBandwidthPrice = medianCurrency(settingsUploadBandwidthPrice)
+			result.Settings.EphemeralAccountExpiry /= time.Duration(medianUint64(settingsEphemeralAccountExpiry))
+			result.Settings.MaxEphemeralAccountBalance = medianCurrency(settingsMaxEphemeralAccountBalance)
+			result.Settings.RevisionNumber = medianUint64(settingsRevisionNumber)
 
-			result.PriceTable.Validity /= time.Duration(count)
-			result.PriceTable.HostBlockHeight /= count
-			result.PriceTable.UpdatePriceTableCost = result.PriceTable.UpdatePriceTableCost.Div64(count)
-			result.PriceTable.AccountBalanceCost = result.PriceTable.AccountBalanceCost.Div64(count)
-			result.PriceTable.FundAccountCost = result.PriceTable.FundAccountCost.Div64(count)
-			result.PriceTable.LatestRevisionCost = result.PriceTable.LatestRevisionCost.Div64(count)
-			result.PriceTable.SubscriptionMemoryCost = result.PriceTable.SubscriptionMemoryCost.Div64(count)
-			result.PriceTable.SubscriptionNotificationCost = result.PriceTable.SubscriptionNotificationCost.Div64(count)
-			result.PriceTable.InitBaseCost = result.PriceTable.InitBaseCost.Div64(count)
-			result.PriceTable.MemoryTimeCost = result.PriceTable.MemoryTimeCost.Div64(count)
-			result.PriceTable.DownloadBandwidthCost = result.PriceTable.DownloadBandwidthCost.Div64(count)
-			result.PriceTable.UploadBandwidthCost = result.PriceTable.UploadBandwidthCost.Div64(count)
-			result.PriceTable.DropSectorsBaseCost = result.PriceTable.DropSectorsBaseCost.Div64(count)
-			result.PriceTable.DropSectorsUnitCost = result.PriceTable.DropSectorsUnitCost.Div64(count)
-			result.PriceTable.HasSectorBaseCost = result.PriceTable.HasSectorBaseCost.Div64(count)
-			result.PriceTable.ReadBaseCost = result.PriceTable.ReadBaseCost.Div64(count)
-			result.PriceTable.ReadLengthCost = result.PriceTable.ReadLengthCost.Div64(count)
-			result.PriceTable.RenewContractCost = result.PriceTable.RenewContractCost.Div64(count)
-			result.PriceTable.RevisionBaseCost = result.PriceTable.RevisionBaseCost.Div64(count)
-			result.PriceTable.SwapSectorBaseCost = result.PriceTable.SwapSectorBaseCost.Div64(count)
-			result.PriceTable.WriteBaseCost = result.PriceTable.WriteBaseCost.Div64(count)
-			result.PriceTable.WriteLengthCost = result.PriceTable.WriteLengthCost.Div64(count)
-			result.PriceTable.WriteStoreCost = result.PriceTable.WriteStoreCost.Div64(count)
-			result.PriceTable.TxnFeeMinRecommended = result.PriceTable.TxnFeeMinRecommended.Div64(count)
-			result.PriceTable.TxnFeeMaxRecommended = result.PriceTable.TxnFeeMaxRecommended.Div64(count)
-			result.PriceTable.ContractPrice = result.PriceTable.ContractPrice.Div64(count)
-			result.PriceTable.CollateralCost = result.PriceTable.CollateralCost.Div64(count)
-			result.PriceTable.MaxCollateral = result.PriceTable.MaxCollateral.Div64(count)
-			result.PriceTable.MaxDuration /= count
-			result.PriceTable.WindowSize /= count
-			result.PriceTable.RegistryEntriesLeft /= count
-			result.PriceTable.RegistryEntriesTotal /= count
+			result.PriceTable.Validity = time.Duration(medianUint64(priceTableValidity))
+			result.PriceTable.HostBlockHeight = medianUint64(priceTableHostBlockHeight)
+			result.PriceTable.UpdatePriceTableCost = medianCurrency(priceTableUpdatePriceTableCost)
+			result.PriceTable.AccountBalanceCost = medianCurrency(priceTableAccountBalanceCost)
+			result.PriceTable.FundAccountCost = medianCurrency(priceTableFundAccountCost)
+			result.PriceTable.LatestRevisionCost = medianCurrency(priceTableLatestRevisionCost)
+			result.PriceTable.SubscriptionMemoryCost = medianCurrency(priceTableSubscriptionMemoryCost)
+			result.PriceTable.SubscriptionNotificationCost = medianCurrency(priceTableSubscriptionNotificationCost)
+			result.PriceTable.InitBaseCost = medianCurrency(priceTableInitBaseCost)
+			result.PriceTable.MemoryTimeCost = medianCurrency(priceTableMemoryTimeCost)
+			result.PriceTable.DownloadBandwidthCost = medianCurrency(priceTableDownloadBandwidthCost)
+			result.PriceTable.UploadBandwidthCost = medianCurrency(priceTableUploadBandwidthCost)
+			result.PriceTable.DropSectorsBaseCost = medianCurrency(priceTableDropSectorsBaseCost)
+			result.PriceTable.DropSectorsUnitCost = medianCurrency(priceTableDropSectorsUnitCost)
+			result.PriceTable.HasSectorBaseCost = medianCurrency(priceTableHasSectorBaseCost)
+			result.PriceTable.ReadBaseCost = medianCurrency(priceTableReadBaseCost)
+			result.PriceTable.ReadLengthCost = medianCurrency(priceTableReadLengthCost)
+			result.PriceTable.RenewContractCost = medianCurrency(priceTableRenewContractCost)
+			result.PriceTable.RevisionBaseCost = medianCurrency(priceTableRevisionBaseCost)
+			result.PriceTable.SwapSectorBaseCost = medianCurrency(priceTableSwapSectorBaseCost)
+			result.PriceTable.WriteBaseCost = medianCurrency(priceTableWriteBaseCost)
+			result.PriceTable.WriteLengthCost = medianCurrency(priceTableWriteLengthCost)
+			result.PriceTable.WriteStoreCost = medianCurrency(priceTableWriteStoreCost)
+			result.PriceTable.TxnFeeMinRecommended = medianCurrency(priceTableTxnFeeMinRecommended)
+			result.PriceTable.TxnFeeMaxRecommended = medianCurrency(priceTableTxnFeeMaxRecommended)
+			result.PriceTable.ContractPrice = medianCurrency(priceTableContractPrice)
+			result.PriceTable.CollateralCost = medianCurrency(priceTableCollateralCost)
+			result.PriceTable.MaxCollateral = medianCurrency(priceTableMaxCollateral)
+			result.PriceTable.MaxDuration = medianUint64(priceTableMaxDuration)
+			result.PriceTable.WindowSize = medianUint64(priceTableWindowSize)
+			result.PriceTable.RegistryEntriesLeft = medianUint64(priceTableRegistryEntriesLeft)
+			result.PriceTable.RegistryEntriesTotal = medianUint64(priceTableRegistryEntriesTotal)
 		}
 
 		return nil

--- a/persist/sqlite/metrics.go
+++ b/persist/sqlite/metrics.go
@@ -57,7 +57,6 @@ func (s *Store) HostMetrics() (result explorer.HostMetrics, err error) {
 		defer rows.Close()
 
 		var count uint64
-
 		var settingsMaxDownloadBatchSize, settingsMaxDuration, settingsMaxReviseBatchSize, settingsRemainingStorage, settingsSectorSize, settingsTotalStorage, settingsWindowSize, settingsRevisionNumber, priceTableHostBlockHeight, priceTableMaxDuration, priceTableWindowSize, priceTableRegistryEntriesLeft, priceTableRegistryEntriesTotal, settingsEphemeralAccountExpiry, priceTableValidity []uint64
 		var settingsCollateral, settingsMaxCollateral, settingsBaseRPCPrice, settingsContractPrice, settingsDownloadBandwidthPrice, settingsSectorAccessPrice, settingsStoragePrice, settingsUploadBandwidthPrice, settingsMaxEphemeralAccountBalance, priceTableUpdatePriceTableCost, priceTableAccountBalanceCost, priceTableFundAccountCost, priceTableLatestRevisionCost, priceTableSubscriptionMemoryCost, priceTableSubscriptionNotificationCost, priceTableInitBaseCost, priceTableMemoryTimeCost, priceTableDownloadBandwidthCost, priceTableUploadBandwidthCost, priceTableDropSectorsBaseCost, priceTableDropSectorsUnitCost, priceTableHasSectorBaseCost, priceTableReadBaseCost, priceTableReadLengthCost, priceTableRenewContractCost, priceTableRevisionBaseCost, priceTableSwapSectorBaseCost, priceTableWriteBaseCost, priceTableWriteLengthCost, priceTableWriteStoreCost, priceTableTxnFeeMinRecommended, priceTableTxnFeeMaxRecommended, priceTableContractPrice, priceTableCollateralCost, priceTableMaxCollateral []types.Currency
 		for rows.Next() {
@@ -91,37 +90,40 @@ func (s *Store) HostMetrics() (result explorer.HostMetrics, err error) {
 			priceTableValidity = append(priceTableValidity, uint64(host.PriceTable.Validity))
 			priceTableHostBlockHeight = append(priceTableHostBlockHeight, host.PriceTable.HostBlockHeight)
 			priceTableUpdatePriceTableCost = append(priceTableUpdatePriceTableCost, host.PriceTable.UpdatePriceTableCost)
-			priceTableAccountBalanceCost = append(priceTableAccountBalanceCost, result.PriceTable.AccountBalanceCost)
-			priceTableFundAccountCost = append(priceTableFundAccountCost, result.PriceTable.FundAccountCost)
-			priceTableLatestRevisionCost = append(priceTableLatestRevisionCost, result.PriceTable.LatestRevisionCost)
-			priceTableSubscriptionMemoryCost = append(priceTableSubscriptionMemoryCost, result.PriceTable.SubscriptionMemoryCost)
-			priceTableSubscriptionNotificationCost = append(priceTableSubscriptionNotificationCost, result.PriceTable.SubscriptionNotificationCost)
-			priceTableInitBaseCost = append(priceTableInitBaseCost, result.PriceTable.InitBaseCost)
-			priceTableMemoryTimeCost = append(priceTableMemoryTimeCost, result.PriceTable.MemoryTimeCost)
-			priceTableDownloadBandwidthCost = append(priceTableDownloadBandwidthCost, result.PriceTable.DownloadBandwidthCost)
-			priceTableUploadBandwidthCost = append(priceTableUploadBandwidthCost, result.PriceTable.UploadBandwidthCost)
-			priceTableDropSectorsBaseCost = append(priceTableDropSectorsBaseCost, result.PriceTable.DropSectorsBaseCost)
-			priceTableDropSectorsUnitCost = append(priceTableDropSectorsUnitCost, result.PriceTable.DropSectorsUnitCost)
-			priceTableHasSectorBaseCost = append(priceTableHasSectorBaseCost, result.PriceTable.HasSectorBaseCost)
-			priceTableReadBaseCost = append(priceTableReadBaseCost, result.PriceTable.ReadBaseCost)
-			priceTableReadLengthCost = append(priceTableReadLengthCost, result.PriceTable.ReadLengthCost)
-			priceTableRenewContractCost = append(priceTableRenewContractCost, result.PriceTable.RenewContractCost)
-			priceTableRevisionBaseCost = append(priceTableRevisionBaseCost, result.PriceTable.RevisionBaseCost)
-			priceTableSwapSectorBaseCost = append(priceTableSwapSectorBaseCost, result.PriceTable.SwapSectorBaseCost)
-			priceTableWriteBaseCost = append(priceTableWriteBaseCost, result.PriceTable.WriteBaseCost)
-			priceTableWriteLengthCost = append(priceTableWriteLengthCost, result.PriceTable.WriteLengthCost)
-			priceTableWriteStoreCost = append(priceTableWriteStoreCost, result.PriceTable.WriteStoreCost)
-			priceTableTxnFeeMinRecommended = append(priceTableTxnFeeMinRecommended, result.PriceTable.TxnFeeMinRecommended)
-			priceTableTxnFeeMaxRecommended = append(priceTableTxnFeeMaxRecommended, result.PriceTable.TxnFeeMaxRecommended)
-			priceTableContractPrice = append(priceTableContractPrice, result.PriceTable.ContractPrice)
-			priceTableCollateralCost = append(priceTableCollateralCost, result.PriceTable.CollateralCost)
-			priceTableMaxCollateral = append(priceTableMaxCollateral, result.PriceTable.MaxCollateral)
+			priceTableAccountBalanceCost = append(priceTableAccountBalanceCost, host.PriceTable.AccountBalanceCost)
+			priceTableFundAccountCost = append(priceTableFundAccountCost, host.PriceTable.FundAccountCost)
+			priceTableLatestRevisionCost = append(priceTableLatestRevisionCost, host.PriceTable.LatestRevisionCost)
+			priceTableSubscriptionMemoryCost = append(priceTableSubscriptionMemoryCost, host.PriceTable.SubscriptionMemoryCost)
+			priceTableSubscriptionNotificationCost = append(priceTableSubscriptionNotificationCost, host.PriceTable.SubscriptionNotificationCost)
+			priceTableInitBaseCost = append(priceTableInitBaseCost, host.PriceTable.InitBaseCost)
+			priceTableMemoryTimeCost = append(priceTableMemoryTimeCost, host.PriceTable.MemoryTimeCost)
+			priceTableDownloadBandwidthCost = append(priceTableDownloadBandwidthCost, host.PriceTable.DownloadBandwidthCost)
+			priceTableUploadBandwidthCost = append(priceTableUploadBandwidthCost, host.PriceTable.UploadBandwidthCost)
+			priceTableDropSectorsBaseCost = append(priceTableDropSectorsBaseCost, host.PriceTable.DropSectorsBaseCost)
+			priceTableDropSectorsUnitCost = append(priceTableDropSectorsUnitCost, host.PriceTable.DropSectorsUnitCost)
+			priceTableHasSectorBaseCost = append(priceTableHasSectorBaseCost, host.PriceTable.HasSectorBaseCost)
+			priceTableReadBaseCost = append(priceTableReadBaseCost, host.PriceTable.ReadBaseCost)
+			priceTableReadLengthCost = append(priceTableReadLengthCost, host.PriceTable.ReadLengthCost)
+			priceTableRenewContractCost = append(priceTableRenewContractCost, host.PriceTable.RenewContractCost)
+			priceTableRevisionBaseCost = append(priceTableRevisionBaseCost, host.PriceTable.RevisionBaseCost)
+			priceTableSwapSectorBaseCost = append(priceTableSwapSectorBaseCost, host.PriceTable.SwapSectorBaseCost)
+			priceTableWriteBaseCost = append(priceTableWriteBaseCost, host.PriceTable.WriteBaseCost)
+			priceTableWriteLengthCost = append(priceTableWriteLengthCost, host.PriceTable.WriteLengthCost)
+			priceTableWriteStoreCost = append(priceTableWriteStoreCost, host.PriceTable.WriteStoreCost)
+			priceTableTxnFeeMinRecommended = append(priceTableTxnFeeMinRecommended, host.PriceTable.TxnFeeMinRecommended)
+			priceTableTxnFeeMaxRecommended = append(priceTableTxnFeeMaxRecommended, host.PriceTable.TxnFeeMaxRecommended)
+			priceTableContractPrice = append(priceTableContractPrice, host.PriceTable.ContractPrice)
+			priceTableCollateralCost = append(priceTableCollateralCost, host.PriceTable.CollateralCost)
+			priceTableMaxCollateral = append(priceTableMaxCollateral, host.PriceTable.MaxCollateral)
 			priceTableMaxDuration = append(priceTableMaxDuration, host.PriceTable.MaxDuration)
 			priceTableWindowSize = append(priceTableWindowSize, host.PriceTable.WindowSize)
 			priceTableRegistryEntriesLeft = append(priceTableRegistryEntriesLeft, host.PriceTable.RegistryEntriesLeft)
 			priceTableRegistryEntriesTotal = append(priceTableRegistryEntriesTotal, host.PriceTable.RegistryEntriesTotal)
 
 			count++
+		}
+		if err := rows.Err(); err != nil {
+			return err
 		}
 
 		if count > 0 {


### PR DESCRIPTION
Reduce the influence of outlier hosts with unusually high pricing on metrics.  Currently this results in a substantial disparity between what is displayed on beta.siascan.com and siascan.com.