### PR TITLE
Prevent scanning functions from hanging on some v1 hosts

### DIFF
--- a/cmd/explored/main.go
+++ b/cmd/explored/main.go
@@ -46,7 +46,7 @@ var cfg = config.Config{
 	},
 	Scanner: config.Scanner{
 		Threads:             10,
-		Timeout:             30 * time.Second,
+		Timeout:             1 * time.Minute,
 		MaxLastScan:         1 * time.Hour,
 		MinLastAnnouncement: 365 * 24 * time.Hour,
 	},

--- a/explorer/scan.go
+++ b/explorer/scan.go
@@ -54,12 +54,18 @@ func (e *Explorer) waitForSync() error {
 	return nil
 }
 
-func rhpv2Settings(ctx context.Context, deadline time.Time, publicKey types.PublicKey, netAddress string) (crhpv2.HostSettings, error) {
+func rhpv2Settings(ctx context.Context, publicKey types.PublicKey, netAddress string) (crhpv2.HostSettings, error) {
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", netAddress)
 	if err != nil {
 		return crhpv2.HostSettings{}, fmt.Errorf("failed to connect to host: %w", err)
 	}
 	defer conn.Close()
+
+	// default timeout if context doesn't have one
+	deadline := time.Now().Add(30 * time.Second)
+	if dl, ok := ctx.Deadline(); ok && !dl.IsZero() {
+		deadline = dl
+	}
 	if err := conn.SetDeadline(deadline); err != nil {
 		return crhpv2.HostSettings{}, fmt.Errorf("failed to set deadline: %w", err)
 	}
@@ -77,12 +83,18 @@ func rhpv2Settings(ctx context.Context, deadline time.Time, publicKey types.Publ
 	return settings, nil
 }
 
-func rhpv3PriceTable(ctx context.Context, deadline time.Time, publicKey types.PublicKey, netAddress string) (priceTable crhpv3.HostPriceTable, err error) {
+func rhpv3PriceTable(ctx context.Context, publicKey types.PublicKey, netAddress string) (priceTable crhpv3.HostPriceTable, err error) {
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", netAddress)
 	if err != nil {
 		return crhpv3.HostPriceTable{}, fmt.Errorf("failed to connect to siamux port: %w", err)
 	}
 	defer conn.Close()
+
+	// default timeout if context doesn't have one
+	deadline := time.Now().Add(30 * time.Second)
+	if dl, ok := ctx.Deadline(); ok && !dl.IsZero() {
+		deadline = dl
+	}
 	if err := conn.SetDeadline(deadline); err != nil {
 		return crhpv3.HostPriceTable{}, fmt.Errorf("failed to set deadline: %w", err)
 	}
@@ -104,13 +116,7 @@ func (e *Explorer) scanV1Host(locator geoip.Locator, host UnscannedHost) (HostSc
 	ctx, cancel := context.WithTimeout(e.ctx, e.scanCfg.Timeout)
 	defer cancel()
 
-	// default timeout if context doesn't have one
-	deadline := time.Now().Add(e.scanCfg.Timeout)
-	if dl, ok := ctx.Deadline(); ok && !dl.IsZero() {
-		deadline = dl
-	}
-
-	settings, err := rhpv2Settings(ctx, deadline, host.PublicKey, host.NetAddress)
+	settings, err := rhpv2Settings(ctx, host.PublicKey, host.NetAddress)
 	if err != nil {
 		return HostScan{}, fmt.Errorf("scanV1Host: failed to get host settings: %w", err)
 	}
@@ -120,7 +126,7 @@ func (e *Explorer) scanV1Host(locator geoip.Locator, host UnscannedHost) (HostSc
 		return HostScan{}, fmt.Errorf("scanV1Host: failed to parse net address: %w", err)
 	}
 
-	table, err := rhpv3PriceTable(ctx, deadline, host.PublicKey, net.JoinHostPort(hostIP, settings.SiaMuxPort))
+	table, err := rhpv3PriceTable(ctx, host.PublicKey, net.JoinHostPort(hostIP, settings.SiaMuxPort))
 	if err != nil {
 		return HostScan{}, fmt.Errorf("scanV1Host: failed to get price table: %w", err)
 	}

--- a/explorer/scan.go
+++ b/explorer/scan.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	crhpv2 "go.sia.tech/core/rhp/v2"
+	crhpv3 "go.sia.tech/core/rhp/v3"
 	"go.sia.tech/core/types"
 	crhpv4 "go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
@@ -53,53 +54,101 @@ func (e *Explorer) waitForSync() error {
 	return nil
 }
 
+func rhpv2Settings(ctx context.Context, publicKey types.PublicKey, netAddress string) (settings crhpv2.HostSettings, err error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", netAddress)
+	if err != nil {
+		return crhpv2.HostSettings{}, fmt.Errorf("scanV1Host: failed to connect to host: %w", err)
+	}
+	defer conn.Close()
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+	// default timeout if context doesn't have one
+	deadline := time.Now().Add(10 * time.Second)
+	if dl, ok := ctx.Deadline(); ok && !dl.IsZero() {
+		deadline = dl
+	}
+
+	if err := conn.SetDeadline(deadline); err != nil {
+		return crhpv2.HostSettings{}, fmt.Errorf("failed to set deadline: %w", err)
+	}
+	t, err := crhpv2.NewRenterTransport(conn, publicKey)
+	if err != nil {
+		return crhpv2.HostSettings{}, fmt.Errorf("failed to establish rhpv2 transport: %w", err)
+	}
+	defer t.Close()
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		return crhpv2.HostSettings{}, fmt.Errorf("failed to clear deadline: %w", err)
+	}
+
+	settings, err = rhpv2.RPCSettings(ctx, t)
+	if err != nil {
+		return crhpv2.HostSettings{}, fmt.Errorf("failed to retrieve rhpv2 settings: %w", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic (withTransportV2): %v", r)
+		}
+	}()
+	return
+}
+
+func rhpv3PriceTable(ctx context.Context, publicKey types.PublicKey, netAddress string) (priceTable crhpv3.HostPriceTable, err error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", netAddress)
+	if err != nil {
+		return crhpv3.HostPriceTable{}, fmt.Errorf("failed to connect to siamux port: %w", err)
+	}
+	defer conn.Close()
+
+	v3Session, err := rhpv3.NewSession(ctx, conn, publicKey, nil, nil)
+	if err != nil {
+		return crhpv3.HostPriceTable{}, fmt.Errorf("failed to establish v3 transport: %w", err)
+	}
+	defer v3Session.Close()
+
+	table, err := v3Session.ScanPriceTable()
+	if err != nil {
+		return crhpv3.HostPriceTable{}, fmt.Errorf("failed to scan price table: %w", err)
+	}
+
+	return table, nil
+}
+
 func (e *Explorer) scanV1Host(locator geoip.Locator, host UnscannedHost) (HostScan, error) {
 	ctx, cancel := context.WithTimeout(e.ctx, e.scanCfg.Timeout)
 	defer cancel()
 
-	dialer := (&net.Dialer{})
-
-	conn, err := dialer.DialContext(ctx, "tcp", host.NetAddress)
+	settings, err := rhpv2Settings(ctx, host.PublicKey, host.NetAddress)
 	if err != nil {
-		return HostScan{}, fmt.Errorf("scanHost: failed to connect to host: %w", err)
-	}
-	defer conn.Close()
-
-	transport, err := crhpv2.NewRenterTransport(conn, host.PublicKey)
-	if err != nil {
-		return HostScan{}, fmt.Errorf("scanHost: failed to establish v2 transport: %w", err)
-	}
-	defer transport.Close()
-
-	settings, err := rhpv2.RPCSettings(ctx, transport)
-	if err != nil {
-		return HostScan{}, fmt.Errorf("scanHost: failed to get host settings: %w", err)
+		return HostScan{}, fmt.Errorf("scanV1Host: failed to get host settings: %w", err)
 	}
 
 	hostIP, _, err := net.SplitHostPort(settings.NetAddress)
 	if err != nil {
-		return HostScan{}, fmt.Errorf("scanHost: failed to parse net address: %w", err)
+		return HostScan{}, fmt.Errorf("scanV1Host: failed to parse net address: %w", err)
+	}
+
+	table, err := rhpv3PriceTable(ctx, host.PublicKey, net.JoinHostPort(hostIP, settings.SiaMuxPort))
+	if err != nil {
+		return HostScan{}, fmt.Errorf("scanV1Host: failed to get price table: %w", err)
 	}
 
 	resolved, err := net.ResolveIPAddr("ip", hostIP)
 	if err != nil {
-		return HostScan{}, fmt.Errorf("scanHost: failed to resolve host address: %w", err)
+		return HostScan{}, fmt.Errorf("scanV1Host: failed to resolve host address: %w", err)
 	}
 
 	location, err := locator.Locate(resolved)
 	if err != nil {
 		e.log.Debug("Failed to resolve IP geolocation, not setting country code", zap.String("addr", host.NetAddress))
-	}
-
-	v3Addr := net.JoinHostPort(hostIP, settings.SiaMuxPort)
-	v3Session, err := rhpv3.NewSession(ctx, host.PublicKey, v3Addr, e.cm, nil)
-	if err != nil {
-		return HostScan{}, fmt.Errorf("scanHost: failed to establish v3 transport: %w", err)
-	}
-
-	table, err := v3Session.ScanPriceTable()
-	if err != nil {
-		return HostScan{}, fmt.Errorf("scanHost: failed to scan price table: %w", err)
 	}
 
 	return HostScan{

--- a/explorer/scan.go
+++ b/explorer/scan.go
@@ -76,7 +76,11 @@ func rhpv2Settings(ctx context.Context, publicKey types.PublicKey, netAddress st
 	}
 	defer t.Close()
 
-	return rhpv2.RPCSettings(ctx, t)
+	settings, err := rhpv2.RPCSettings(ctx, t)
+	if err != nil {
+		return crhpv2.HostSettings{}, fmt.Errorf("failed to call settings RPC: %w", err)
+	}
+	return settings, nil
 }
 
 func rhpv3PriceTable(ctx context.Context, publicKey types.PublicKey, netAddress string) (priceTable crhpv3.HostPriceTable, err error) {

--- a/internal/rhp/v3/rhp.go
+++ b/internal/rhp/v3/rhp.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"math/bits"
 	"net"
+	"time"
 
 	"go.sia.tech/core/consensus"
 	rhp2 "go.sia.tech/core/rhp/v2"
@@ -799,15 +800,31 @@ func AccountPayment(account rhp3.Account, privateKey types.PrivateKey) PaymentMe
 }
 
 // NewSession creates a new session with a host
-func NewSession(ctx context.Context, hostKey types.PublicKey, hostAddr string, cm ChainManager, w Wallet) (*Session, error) {
-	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", hostAddr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial host: %w", err)
+func NewSession(ctx context.Context, conn net.Conn, hostKey types.PublicKey, cm ChainManager, w Wallet) (*Session, error) {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+	// default timeout if context doesn't have one
+	deadline := time.Now().Add(10 * time.Second)
+	if dl, ok := ctx.Deadline(); ok && !dl.IsZero() {
+		deadline = dl
+	}
+
+	if err := conn.SetDeadline(deadline); err != nil {
+		return nil, fmt.Errorf("failed to set deadline: %w", err)
 	}
 	t, err := rhp3.NewRenterTransport(conn, hostKey)
 	if err != nil {
-		conn.Close()
 		return nil, fmt.Errorf("failed to create transport: %w", err)
+	}
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		return nil, fmt.Errorf("failed to clear deadline: %w", err)
 	}
 
 	return &Session{


### PR DESCRIPTION
If a host responds but with an incompatible protocol (or just extremely slowly), the RHP code will wait for a response of a certain size indefinitely.  This PR adds connection deadlines to prevent that from happening.  This fixes the low host count on beta.siascan.com that has happened because some scanning goroutines never finished, so the WaitGroup never finished either, which meant scans stopped being added to the database.

A similar issue with v2 hosts came up lately that was fixed by upgrading coreutils: https://github.com/SiaFoundation/explored/pull/180