### PR TITLE
Fix v2 output sources

### DIFF
--- a/explorer/update.go
+++ b/explorer/update.go
@@ -90,6 +90,13 @@ func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate) error {
 		}
 	}
 
+	for _, txn := range cau.Block.V2Transactions() {
+		txnID := txn.ID()
+		for i := range txn.SiacoinOutputs {
+			sources[txn.SiacoinOutputID(txnID, i)] = SourceTransaction
+		}
+	}
+
 	for _, diff := range cau.FileContractElementDiffs() {
 		if diff.Resolved {
 			fcID := diff.FileContractElement.ID

--- a/internal/testutil/check.go
+++ b/internal/testutil/check.go
@@ -159,6 +159,7 @@ func CheckV2Transaction(t *testing.T, expectTxn types.V2Transaction, gotTxn expl
 
 		Equal(t, "address", expected.Address, got.Address)
 		Equal(t, "value", expected.Value, got.Value)
+		Equal(t, "source", explorer.SourceTransaction, gotTxn.SiacoinOutputs[i].Source)
 	}
 
 	Equal(t, "siafund inputs", len(expectTxn.SiafundInputs), len(gotTxn.SiafundInputs))


### PR DESCRIPTION
Set the source field equal to `SourceTransaction` for siacoin outputs from v2 transactions where applicable.  Add check similar to one we have for [v1](https://github.com/SiaFoundation/explored/blob/master/internal/testutil/check.go#L62) to ensure that the source field is set in the transactions we retrieve from the explorer.