### PR TITLE
Expose type of resolution for v2 contracts

### DIFF
--- a/explorer/events.go
+++ b/explorer/events.go
@@ -353,7 +353,6 @@ func CoreToExplorerV2Transaction(txn types.V2Transaction) (result V2Transaction)
 		parent.V2FileContractElement.StateElement = fcr.Parent.StateElement
 
 		var res any
-		var typ ResolutionType
 		switch v := fcr.Resolution.(type) {
 		case *types.V2FileContractRenewal:
 			res = V2FileContractRenewal{
@@ -366,17 +365,14 @@ func CoreToExplorerV2Transaction(txn types.V2Transaction) (result V2Transaction)
 				RenterSignature: v.RenterSignature,
 				HostSignature:   v.HostSignature,
 			}
-			typ = ResolutionTypeRenewal
 		case *types.V2StorageProof:
 			res = v
-			typ = ResolutionTypeStorageProof
 		case *types.V2FileContractExpiration:
 			res = v
-			typ = ResolutionTypeExpiration
 		}
 		result.FileContractResolutions = append(result.FileContractResolutions, V2FileContractResolution{
 			Parent:     parent,
-			Type:       typ,
+			Type:       V2ResolutionType(fcr.Resolution),
 			Resolution: res,
 		})
 	}
@@ -539,14 +535,14 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) (events []
 			missed = true
 		}
 
-		var typ ResolutionType
+		var typ V2Resolution
 		switch res.(type) {
 		case *types.V2FileContractRenewal:
-			typ = ResolutionTypeRenewal
+			typ = V2ResolutionRenewal
 		case *types.V2StorageProof:
-			typ = ResolutionTypeStorageProof
+			typ = V2ResolutionStorageProof
 		case *types.V2FileContractExpiration:
-			typ = ResolutionTypeStorageProof
+			typ = V2ResolutionStorageProof
 		default:
 			panic("unknown resolution type")
 		}

--- a/explorer/events.go
+++ b/explorer/events.go
@@ -535,24 +535,13 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) (events []
 			missed = true
 		}
 
-		var typ V2Resolution
-		switch res.(type) {
-		case *types.V2FileContractRenewal:
-			typ = V2ResolutionRenewal
-		case *types.V2StorageProof:
-			typ = V2ResolutionStorageProof
-		case *types.V2FileContractExpiration:
-			typ = V2ResolutionStorageProof
-		default:
-			panic("unknown resolution type")
-		}
-
+		resolutionType := V2ResolutionType(res)
 		addV2Resolution := func(element types.SiacoinElement) {
 			efc := V2FileContract{V2FileContractElement: fce}
 			addEvent(types.Hash256(element.ID), element.MaturityHeight, wallet.EventTypeV2ContractResolution, EventV2ContractResolution{
 				Resolution: V2FileContractResolution{
 					Parent:     efc,
-					Type:       typ,
+					Type:       resolutionType,
 					Resolution: res,
 				},
 				SiacoinElement: SiacoinOutput{SiacoinElement: element},

--- a/explorer/types.go
+++ b/explorer/types.go
@@ -168,6 +168,8 @@ func V2ResolutionType(res types.V2FileContractResolutionType) (result V2Resoluti
 		result = V2ResolutionStorageProof
 	case *types.V2FileContractExpiration:
 		result = V2ResolutionExpiration
+	default:
+		panic("unknown resolution type")
 	}
 	return
 }

--- a/internal/testutil/check.go
+++ b/internal/testutil/check.go
@@ -221,7 +221,7 @@ func CheckV2Transaction(t *testing.T, expectTxn types.V2Transaction, gotTxn expl
 			} else {
 				CheckV2FC(t, v.NewContract, gotV.NewContract)
 
-				Equal(t, "type", "renewal", got.Type)
+				Equal(t, "type", explorer.V2ResolutionRenewal, got.Type)
 				Equal(t, "final renter output address", v.FinalRenterOutput.Address, gotV.FinalRenterOutput.Address)
 				Equal(t, "final renter output value", v.FinalRenterOutput.Value, gotV.FinalRenterOutput.Value)
 				Equal(t, "final host output address", v.FinalHostOutput.Address, gotV.FinalHostOutput.Address)
@@ -235,13 +235,13 @@ func CheckV2Transaction(t *testing.T, expectTxn types.V2Transaction, gotTxn expl
 			if gotV, ok := got.Resolution.(*types.V2StorageProof); !ok {
 				t.Fatalf("expected V2StorageProof, got %v", reflect.TypeOf(got.Resolution))
 			} else {
-				Equal(t, "type", "storageProof", got.Type)
+				Equal(t, "type", explorer.V2ResolutionStorageProof, got.Type)
 				Equal(t, "proof index", v.ProofIndex, gotV.ProofIndex)
 				Equal(t, "leaf", v.Leaf, gotV.Leaf)
 				Equal(t, "proof", v.Proof, gotV.Proof)
 			}
 		case *types.V2FileContractExpiration:
-			Equal(t, "type", "expiration", got.Type)
+			Equal(t, "type", explorer.V2ResolutionExpiration, got.Type)
 			if _, ok := got.Resolution.(*types.V2FileContractExpiration); !ok {
 				t.Fatalf("expected V2FileContractExpiration, got %v", reflect.TypeOf(got.Resolution))
 			}

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -335,7 +335,7 @@ CREATE TABLE v2_transaction_file_contract_resolutions (
     transaction_order INTEGER NOT NULL,
     parent_contract_id INTEGER REFERENCES v2_file_contract_elements(id) ON DELETE CASCADE NOT NULL, -- add an index to all foreign keys
 
-    -- V2FileContractRenewal = 0, V2StorageProof = 1, V2FileContractExpiration = 2
+    -- See explorer.V2Resolution for enum values.
     resolution_type INTEGER NOT NULL,
 
     -- V2FileContractRenewal
@@ -466,7 +466,7 @@ CREATE TABLE v2_last_contract_revision (
     confirmation_block_id BLOB NOT NULL REFERENCES blocks(id) ON DELETE CASCADE,
     confirmation_transaction_id BLOB NOT NULL REFERENCES v2_transactions(transaction_id),
 
-    -- V2FileContractRenewal = 0, V2StorageProof = 1, V2FileContractExpiration = 2
+    -- See explorer.V2Resolution for enum values.
     resolution_type INTEGER,
     resolution_height BLOB,
     resolution_block_id BLOB,

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -466,6 +466,8 @@ CREATE TABLE v2_last_contract_revision (
     confirmation_block_id BLOB NOT NULL REFERENCES blocks(id) ON DELETE CASCADE,
     confirmation_transaction_id BLOB NOT NULL REFERENCES v2_transactions(transaction_id),
 
+    -- V2FileContractRenewal = 0, V2StorageProof = 1, V2FileContractExpiration = 2
+    resolution_type INTEGER,
     resolution_height BLOB,
     resolution_block_id BLOB,
     resolution_transaction_id BLOB REFERENCES v2_transactions(transaction_id),

--- a/persist/sqlite/v2consensus_test.go
+++ b/persist/sqlite/v2consensus_test.go
@@ -1111,6 +1111,7 @@ func TestV2FileContractResolution(t *testing.T) {
 
 		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
 		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
+		testutil.Equal(t, "resolution type", explorer.V2ResolutionRenewal, *dbTxns[0].FileContractResolutions[0].Parent.ResolutionType)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn2.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}
@@ -1150,6 +1151,7 @@ func TestV2FileContractResolution(t *testing.T) {
 		testutil.CheckV2Transaction(t, txn3, dbTxns[0])
 		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
 		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
+		testutil.Equal(t, "resolution type", explorer.V2ResolutionStorageProof, *dbTxns[0].FileContractResolutions[0].Parent.ResolutionType)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn3.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}
@@ -1177,6 +1179,7 @@ func TestV2FileContractResolution(t *testing.T) {
 		testutil.CheckV2Transaction(t, txn4, dbTxns[0])
 		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
 		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
+		testutil.Equal(t, "resolution type", explorer.V2ResolutionExpiration, *dbTxns[0].FileContractResolutions[0].Parent.ResolutionType)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn4.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}
@@ -1317,6 +1320,7 @@ func TestV2FileContractResolution(t *testing.T) {
 		testutil.CheckV2Transaction(t, txn3, dbTxns[0])
 		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
 		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
+		testutil.Equal(t, "resolution type", explorer.V2ResolutionStorageProof, *dbTxns[0].FileContractResolutions[0].Parent.ResolutionType)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn3.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}
@@ -1337,6 +1341,7 @@ func TestV2FileContractResolution(t *testing.T) {
 		testutil.CheckV2Transaction(t, txn4, dbTxns[0])
 		testutil.Equal(t, "confirmation index", tip1, dbTxns[0].FileContractResolutions[0].Parent.ConfirmationIndex)
 		testutil.Equal(t, "confirmation transaction ID", txn1.ID(), dbTxns[0].FileContractResolutions[0].Parent.ConfirmationTransactionID)
+		testutil.Equal(t, "resolution type", explorer.V2ResolutionExpiration, *dbTxns[0].FileContractResolutions[0].Parent.ResolutionType)
 		testutil.Equal(t, "resolution index", cm.Tip(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionIndex)
 		testutil.Equal(t, "resolution transaction ID", txn4.ID(), *dbTxns[0].FileContractResolutions[0].Parent.ResolutionTransactionID)
 	}

--- a/persist/sqlite/v2consensus_test.go
+++ b/persist/sqlite/v2consensus_test.go
@@ -1055,6 +1055,21 @@ func TestV2FileContractResolution(t *testing.T) {
 		testutil.CheckV2FC(t, txn1.FileContracts[3], fcs[3])
 	}
 
+	// check that they are all not resolved before resolving
+	{
+		fcs, err := db.V2Contracts([]types.FileContractID{v2FC0ID, v2FC1ID, v2FC2ID, v2FC3ID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, fc := range fcs {
+			testutil.Equal(t, "confirmation index", tip1, fc.ConfirmationIndex)
+			testutil.Equal(t, "confirmation transaction ID", txn1.ID(), fc.ConfirmationTransactionID)
+			testutil.Equal(t, "resolution type", nil, fc.ResolutionType)
+			testutil.Equal(t, "resolution index", nil, fc.ResolutionIndex)
+			testutil.Equal(t, "resolution transaction ID", nil, fc.ResolutionTransactionID)
+		}
+	}
+
 	// we will revert back here when we undo the resolutions
 	prevState := cm.TipState()
 
@@ -1284,6 +1299,21 @@ func TestV2FileContractResolution(t *testing.T) {
 			t.Fatal(err)
 		}
 		syncDB(t, db, cm)
+	}
+
+	// check that they are all not resolved after reverting resolution
+	{
+		fcs, err := db.V2Contracts([]types.FileContractID{v2FC0ID, v2FC1ID, v2FC2ID, v2FC3ID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, fc := range fcs {
+			testutil.Equal(t, "confirmation index", tip1, fc.ConfirmationIndex)
+			testutil.Equal(t, "confirmation transaction ID", txn1.ID(), fc.ConfirmationTransactionID)
+			testutil.Equal(t, "resolution type", nil, fc.ResolutionType)
+			testutil.Equal(t, "resolution index", nil, fc.ResolutionIndex)
+			testutil.Equal(t, "resolution transaction ID", nil, fc.ResolutionTransactionID)
+		}
 	}
 
 	{

--- a/persist/sqlite/v2contracts.go
+++ b/persist/sqlite/v2contracts.go
@@ -10,14 +10,18 @@ import (
 )
 
 func scanV2FileContract(s scanner) (fce explorer.V2FileContract, err error) {
+	var resolutionType sql.Null[explorer.V2Resolution]
 	var resolutionIndex types.ChainIndex
 	var resolutionTransactionID types.TransactionID
 
 	fc := &fce.V2FileContractElement.V2FileContract
-	if err = s.Scan(decode(&fce.TransactionID), decode(&fce.ConfirmationIndex.Height), decode(&fce.ConfirmationIndex.ID), decode(&fce.ConfirmationTransactionID), decodeNull(&resolutionIndex.Height), decodeNull(&resolutionIndex.ID), decodeNull(&resolutionTransactionID), decode(&fce.V2FileContractElement.ID), decode(&fce.V2FileContractElement.StateElement.LeafIndex), decode(&fc.Capacity), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.ProofHeight), decode(&fc.ExpirationHeight), decode(&fc.RenterOutput.Address), decode(&fc.RenterOutput.Value), decode(&fc.HostOutput.Address), decode(&fc.HostOutput.Value), decode(&fc.MissedHostValue), decode(&fc.TotalCollateral), decode(&fc.RenterPublicKey), decode(&fc.HostPublicKey), decode(&fc.RevisionNumber), decode(&fc.RenterSignature), decode(&fc.HostSignature)); err != nil {
+	if err = s.Scan(decode(&fce.TransactionID), decode(&fce.ConfirmationIndex.Height), decode(&fce.ConfirmationIndex.ID), decode(&fce.ConfirmationTransactionID), &resolutionType, decodeNull(&resolutionIndex.Height), decodeNull(&resolutionIndex.ID), decodeNull(&resolutionTransactionID), decode(&fce.V2FileContractElement.ID), decode(&fce.V2FileContractElement.StateElement.LeafIndex), decode(&fc.Capacity), decode(&fc.Filesize), decode(&fc.FileMerkleRoot), decode(&fc.ProofHeight), decode(&fc.ExpirationHeight), decode(&fc.RenterOutput.Address), decode(&fc.RenterOutput.Value), decode(&fc.HostOutput.Address), decode(&fc.HostOutput.Value), decode(&fc.MissedHostValue), decode(&fc.TotalCollateral), decode(&fc.RenterPublicKey), decode(&fc.HostPublicKey), decode(&fc.RevisionNumber), decode(&fc.RenterSignature), decode(&fc.HostSignature)); err != nil {
 		return
 	}
 
+	if resolutionType.Valid {
+		fce.ResolutionType = &resolutionType.V
+	}
 	if resolutionIndex != (types.ChainIndex{}) {
 		fce.ResolutionIndex = &resolutionIndex
 	}
@@ -31,7 +35,7 @@ func scanV2FileContract(s scanner) (fce explorer.V2FileContract, err error) {
 // V2Contracts implements explorer.Store.
 func (s *Store) V2Contracts(ids []types.FileContractID) (result []explorer.V2FileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		stmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+		stmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_type, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_last_contract_revision rev
 INNER JOIN v2_file_contract_elements fc ON rev.contract_element_id = fc.id
 WHERE rev.contract_id = ?
@@ -59,7 +63,7 @@ WHERE rev.contract_id = ?
 // V2ContractRevisions implements explorer.Store.
 func (s *Store) V2ContractRevisions(id types.FileContractID) (revisions []explorer.V2FileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		query := `SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+		query := `SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_type, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_last_contract_revision rev ON rev.contract_id = fc.contract_id
 WHERE fc.contract_id = ?
@@ -92,7 +96,7 @@ ORDER BY fc.revision_number ASC
 func (s *Store) V2ContractsKey(key types.PublicKey) (result []explorer.V2FileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
 		encoded := encode(key)
-		rows, err := tx.Query(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+		rows, err := tx.Query(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_type, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_last_contract_revision rev
 INNER JOIN v2_file_contract_elements fc ON rev.contract_element_id = fc.id
 WHERE fc.renter_public_key = ? OR fc.host_public_key = ?

--- a/persist/sqlite/v2contracts.go
+++ b/persist/sqlite/v2contracts.go
@@ -19,7 +19,7 @@ func scanV2FileContract(s scanner) (fce explorer.V2FileContract, err error) {
 		return
 	}
 
-	if resolutionType.Valid {
+	if resolutionType.Valid && resolutionType.V != explorer.V2ResolutionInvalid {
 		fce.ResolutionType = &resolutionType.V
 	}
 	if resolutionIndex != (types.ChainIndex{}) {

--- a/persist/sqlite/v2transactions.go
+++ b/persist/sqlite/v2transactions.go
@@ -322,7 +322,7 @@ ORDER BY ts.transaction_order ASC`)
 // fillV2TransactionFileContracts fills in the file contracts for each
 // transaction.
 func fillV2TransactionFileContracts(tx *txn, dbIDs []int64, txns []explorer.V2Transaction) error {
-	stmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+	stmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_type, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_transaction_file_contracts ts ON (ts.contract_id = fc.id)
 INNER JOIN v2_last_contract_revision rev ON (rev.contract_id = fc.contract_id)
@@ -361,7 +361,7 @@ ORDER BY ts.transaction_order ASC`)
 // fillV2TransactionFileContractRevisions fills in the file contract revisions
 // for each transaction.
 func fillV2TransactionFileContractRevisions(tx *txn, dbIDs []int64, txns []explorer.V2Transaction) error {
-	parentStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+	parentStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_type, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_transaction_file_contract_revisions ts ON (ts.parent_contract_id = fc.id)
 INNER JOIN v2_last_contract_revision rev ON (rev.contract_id = fc.contract_id)
@@ -372,7 +372,7 @@ ORDER BY ts.transaction_order ASC`)
 	}
 	defer parentStmt.Close()
 
-	revisionStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+	revisionStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_type, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_transaction_file_contract_revisions ts ON (ts.revision_contract_id = fc.id)
 INNER JOIN v2_last_contract_revision rev ON (rev.contract_id = fc.contract_id)
@@ -449,7 +449,7 @@ func fillV2TransactionFileContractResolutions(tx *txn, dbIDs []int64, txns []exp
 	defer consolidatedStmt.Close()
 
 	// get a v2 FC by id
-	fcStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
+	fcStmt, err := tx.Prepare(`SELECT fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.resolution_type, rev.resolution_height, rev.resolution_block_id, rev.resolution_transaction_id, fc.contract_id, fc.leaf_index, fc.capacity, fc.filesize, fc.file_merkle_root, fc.proof_height, fc.expiration_height, fc.renter_output_address, fc.renter_output_value, fc.host_output_address, fc.host_output_value, fc.missed_host_value, fc.total_collateral, fc.renter_public_key, fc.host_public_key, fc.revision_number, fc.renter_signature, fc.host_signature
 FROM v2_file_contract_elements fc
 INNER JOIN v2_last_contract_revision rev ON (rev.contract_id = fc.contract_id)
 WHERE fc.id = ?`)

--- a/persist/sqlite/v2transactions.go
+++ b/persist/sqlite/v2transactions.go
@@ -499,9 +499,10 @@ WHERE fc.id = ?`)
 
 				fcr := explorer.V2FileContractResolution{
 					Parent: parent,
+					Type:   explorer.V2Resolution(resolutionType),
 				}
-				switch resolutionType {
-				case 0: // V2FileContractRenewal
+				switch fcr.Type {
+				case explorer.V2ResolutionRenewal:
 					renewal := &explorer.V2FileContractRenewal{
 						FinalRenterOutput: finalRenterOutput,
 						FinalHostOutput:   finalHostOutput,
@@ -516,20 +517,15 @@ WHERE fc.id = ?`)
 							return fmt.Errorf("failed to scan new contract: %w", err)
 						}
 					}
-
-					fcr.Type = explorer.ResolutionTypeRenewal
 					fcr.Resolution = renewal
-				case 1: // V2StorageProof
+				case explorer.V2ResolutionStorageProof:
 					proof := &types.V2StorageProof{
 						ProofIndex: storageProofProofIndex,
 						Proof:      storageProofProof,
 						Leaf:       [64]byte(storageProofLeaf),
 					}
-
-					fcr.Type = explorer.ResolutionTypeStorageProof
 					fcr.Resolution = proof
-				case 2: // V2FileContractExpiration
-					fcr.Type = explorer.ResolutionTypeExpiration
+				case explorer.V2ResolutionExpiration:
 					fcr.Resolution = new(types.V2FileContractExpiration)
 				}
 


### PR DESCRIPTION
Add field to `V2FileContract` which represents the type of resolution, if there was one.  It can either be a `V2ResolutionRenewal`, `V2ResolutionStorageProof`, or `V2ResolutionExpiration`.  This saves consumers from having to retrieve the transaction using the resolution transaction ID to figure out the resolution type.