### PR TITLE
Don't wait for explorer to catch up before starting

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -149,16 +149,6 @@ func NewExplorer(cm ChainManager, store Store, indexCfg config.Index, scanCfg co
 	}
 	e.locator = locator
 
-	tip, err := e.s.Tip()
-	if errors.Is(err, ErrNoTip) {
-		tip = types.ChainIndex{}
-	} else if err != nil {
-		return nil, fmt.Errorf("failed to get tip: %w", err)
-	}
-	if err := e.syncStore(tip, indexCfg.BatchSize); err != nil {
-		return nil, fmt.Errorf("failed to subscribe to chain manager: %w", err)
-	}
-
 	reorgChan := make(chan types.ChainIndex, 1)
 	go func() {
 		for range reorgChan {

--- a/persist/sqlite/blocks.go
+++ b/persist/sqlite/blocks.go
@@ -62,13 +62,14 @@ func (s *Store) Block(id types.BlockID) (result explorer.Block, err error) {
 func (s *Store) Tip() (result types.ChainIndex, err error) {
 	const query = `SELECT id, height FROM blocks ORDER BY height DESC LIMIT 1`
 	err = s.transaction(func(dbTxn *txn) error {
-		return dbTxn.QueryRow(query).Scan(decode(&result.ID), &result.Height)
+		err := dbTxn.QueryRow(query).Scan(decode(&result.ID), &result.Height)
+		if errors.Is(err, sql.ErrNoRows) {
+			return explorer.ErrNoTip
+		} else if err != nil {
+			return err
+		}
+		return nil
 	})
-	if errors.Is(err, sql.ErrNoRows) {
-		return types.ChainIndex{}, nil
-	} else if err != nil {
-		return types.ChainIndex{}, err
-	}
 	return
 }
 

--- a/persist/sqlite/blocks.go
+++ b/persist/sqlite/blocks.go
@@ -62,15 +62,13 @@ func (s *Store) Block(id types.BlockID) (result explorer.Block, err error) {
 func (s *Store) Tip() (result types.ChainIndex, err error) {
 	const query = `SELECT id, height FROM blocks ORDER BY height DESC LIMIT 1`
 	err = s.transaction(func(dbTxn *txn) error {
-		err := dbTxn.QueryRow(query).Scan(decode(&result.ID), &result.Height)
-		if errors.Is(err, sql.ErrNoRows) {
-			return explorer.ErrNoTip
-		} else if err != nil {
-			return err
-		}
-
-		return nil
+		return dbTxn.QueryRow(query).Scan(decode(&result.ID), &result.Height)
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return types.ChainIndex{}, nil
+	} else if err != nil {
+		return types.ChainIndex{}, err
+	}
 	return
 }
 

--- a/persist/sqlite/scan_test.go
+++ b/persist/sqlite/scan_test.go
@@ -377,20 +377,13 @@ func TestScan(t *testing.T) {
 	waitForTip := func() {
 		t.Helper()
 
-		const duration = time.Second
 		for {
-			tip, err := e.Tip()
-			if errors.Is(err, explorer.ErrNoTip) {
-				time.Sleep(duration)
-				continue
-			} else if err != nil {
+			if tip, err := e.Tip(); err != nil && !errors.Is(err, explorer.ErrNoTip) {
 				t.Fatal(err)
-			}
-			if tip != cm.Tip() {
-				time.Sleep(duration)
-			} else {
+			} else if tip == cm.Tip() {
 				break
 			}
+			time.Sleep(time.Second)
 		}
 	}
 	waitForTip()

--- a/persist/sqlite/scan_test.go
+++ b/persist/sqlite/scan_test.go
@@ -376,13 +376,18 @@ func TestScan(t *testing.T) {
 
 	waitForTip := func() {
 		t.Helper()
+
+		const duration = time.Second
 		for {
 			tip, err := e.Tip()
-			if err != nil {
+			if errors.Is(err, explorer.ErrNoTip) {
+				time.Sleep(duration)
+				continue
+			} else if err != nil {
 				t.Fatal(err)
 			}
 			if tip != cm.Tip() {
-				time.Sleep(time.Second)
+				time.Sleep(duration)
 			} else {
 				break
 			}


### PR DESCRIPTION
Resolve issue where exchange rates (or any API endpoint) would timeout when explorer was given an existing consensus DB because NewExplorer was blocking on indexing chain data to the current chain manager tip.  Manually tested