### PR TITLE
Index genesis block in NewExplorer

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -149,6 +149,12 @@ func NewExplorer(cm ChainManager, store Store, indexCfg config.Index, scanCfg co
 	}
 	e.locator = locator
 
+	if _, err := e.s.Tip(); errors.Is(err, ErrNoTip) {
+		if err := e.syncStore(types.ChainIndex{}, 1); err != nil {
+			e.log.Panic("failed to add genesis block", zap.Error(err))
+		}
+	}
+
 	reorgChan := make(chan types.ChainIndex, 1)
 	go func() {
 		for range reorgChan {

--- a/persist/sqlite/scan_test.go
+++ b/persist/sqlite/scan_test.go
@@ -378,7 +378,7 @@ func TestScan(t *testing.T) {
 		t.Helper()
 
 		for {
-			if tip, err := e.Tip(); err != nil && !errors.Is(err, explorer.ErrNoTip) {
+			if tip, err := e.Tip(); err != nil {
 				t.Fatal(err)
 			} else if tip == cm.Tip() {
 				break


### PR DESCRIPTION
We don't need to do a full index before returning, but adding at least the genesis block is nice because it means that by the time we return from `NewExplorer`, there will at least be *a* tip.  This should also fix an issue with clusterd introduced in #194 where the [waitForSync loop times out](https://github.com/SiaFoundation/cluster/blob/master/nodes/explored.go#L188)  because the reorgChan doesn't seem to be sent anything until another block is added.