### PR TITLE
use threadgroup for shutdowns

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: Create Release PR
+jobs:
+  prepare-release:
+    if: "!contains(github.event.head_commit.message, 'chore: prepare release')" # Skip merges from releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config --global user.name github-actions[bot]
+          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: knope-dev/action@407e9ef7c272d2dd53a4e71e39a7839e29933c48
+      - run: knope prepare-release --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+bin
+explored.yaml

--- a/api/server.go
+++ b/api/server.go
@@ -73,7 +73,7 @@ type (
 		V2ContractRevisions(id types.FileContractID) (result []explorer.V2FileContract, err error)
 		Search(id string) (explorer.SearchType, error)
 
-		ScanHosts(pks ...types.PublicKey) ([]explorer.HostScan, error)
+		ScanHosts(context.Context, ...types.PublicKey) ([]explorer.HostScan, error)
 		Hosts(pks []types.PublicKey) ([]explorer.Host, error)
 		QueryHosts(params explorer.HostQuery, sortBy explorer.HostSortColumn, dir explorer.HostSortDir, offset, limit uint64) ([]explorer.Host, error)
 	}
@@ -729,7 +729,7 @@ func (s *server) pubkeyHostScanHandler(jc jape.Context) {
 		return
 	}
 
-	scans, err := s.e.ScanHosts(key)
+	scans, err := s.e.ScanHosts(jc.Request.Context(), key)
 	if jc.Check("non host error when attempting to scan hosts", err) != nil {
 		return
 	} else if len(scans) == 0 {

--- a/explorer/events.go
+++ b/explorer/events.go
@@ -279,19 +279,10 @@ func CoreToExplorerV1Transaction(txn types.Transaction) (result Transaction) {
 			ExtendedFileContract: coreToExplorerFC(fcr.ParentID, fcr.FileContract),
 		})
 	}
-	for _, sp := range txn.StorageProofs {
-		result.StorageProofs = append(result.StorageProofs, sp)
-	}
-	for _, fee := range txn.MinerFees {
-		result.MinerFees = append(result.MinerFees, fee)
-	}
-	for _, arb := range txn.ArbitraryData {
-		result.ArbitraryData = append(result.ArbitraryData, arb)
-	}
-	for _, sig := range txn.Signatures {
-		result.Signatures = append(result.Signatures, sig)
-	}
-
+	result.StorageProofs = append(result.StorageProofs, txn.StorageProofs...)
+	result.MinerFees = append(result.MinerFees, txn.MinerFees...)
+	result.ArbitraryData = append(result.ArbitraryData, txn.ArbitraryData...)
+	result.Signatures = append(result.Signatures, txn.Signatures...)
 	return
 }
 
@@ -313,9 +304,7 @@ func CoreToExplorerV2Transaction(txn types.V2Transaction) (result V2Transaction)
 		}
 	}
 
-	for _, sci := range txn.SiacoinInputs {
-		result.SiacoinInputs = append(result.SiacoinInputs, sci)
-	}
+	result.SiacoinInputs = append(result.SiacoinInputs, txn.SiacoinInputs...)
 	for i, sco := range txn.SiacoinOutputs {
 		sce := types.SiacoinElement{
 			ID:            txn.SiacoinOutputID(result.ID, i),
@@ -325,9 +314,8 @@ func CoreToExplorerV2Transaction(txn types.V2Transaction) (result V2Transaction)
 			SiacoinElement: sce,
 		})
 	}
-	for _, sfi := range txn.SiafundInputs {
-		result.SiafundInputs = append(result.SiafundInputs, sfi)
-	}
+
+	result.SiafundInputs = append(result.SiafundInputs, txn.SiafundInputs...)
 	for i, sfo := range txn.SiafundOutputs {
 		sfe := types.SiafundElement{
 			ID:            txn.SiafundOutputID(result.ID, i),
@@ -388,9 +376,7 @@ func CoreToExplorerV2Transaction(txn types.V2Transaction) (result V2Transaction)
 			})
 		}
 	}
-	for _, arb := range txn.ArbitraryData {
-		result.ArbitraryData = append(result.ArbitraryData, arb)
-	}
+	result.ArbitraryData = append(result.ArbitraryData, txn.ArbitraryData...)
 	result.NewFoundationAddress = txn.NewFoundationAddress
 	result.MinerFee = txn.MinerFee
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -212,7 +212,7 @@ func NewExplorer(cm ChainManager, store Store, indexCfg config.Index, scanCfg co
 
 // Shutdown tries to close the scanning goroutines in the explorer.
 func (e *Explorer) Shutdown(ctx context.Context) error {
-	done := make(chan struct{}, 1)
+	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		e.tg.Stop()

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,56 @@
+[package]
+changelog = "CHANGELOG.md"
+versioned_files = ["go.mod"]
+ignore_go_major_versioning = true
+
+[[workflows]]
+name = "document-change"
+
+[[workflows.steps]]
+type = "CreateChangeFile"
+
+[[workflows]]
+name = "prepare-release"
+
+[[workflows.steps]]
+type = "Command"
+command = "git switch -c release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+ignore_conventional_commits = true
+
+[[workflows.steps]]
+type = "Command"
+command = "git commit -m \"chore: prepare release $version\""
+variables = { "$version" = "Version" }
+
+[[workflows.steps]]
+type = "Command"
+command = "git push --force --set-upstream origin release"
+
+[workflows.steps.variables]
+"$version" = "Version"
+
+[[workflows.steps]]
+type = "CreatePullRequest"
+base = "master"
+
+[workflows.steps.title]
+template = "chore: prepare release $version"
+variables = { "$version" = "Version" }
+
+[workflows.steps.body]
+template = "This PR was created automatically. Merging it will finalize the changelog for $version\n\n$changelog"
+variables = { "$changelog" = "ChangelogEntry", "$version" = "Version" }
+
+# Do not enable releases, just changelogs for now.
+# [[workflows]]
+# name = "release"
+#
+# [[workflows.steps]]
+# type = "Release"
+
+[github]
+owner = "SiaFoundation"
+repo = "explored"

--- a/persist/sqlite/scan_test.go
+++ b/persist/sqlite/scan_test.go
@@ -594,7 +594,7 @@ func TestScan(t *testing.T) {
 	}
 
 	// Manually scan all the hosts
-	if _, err := e.ScanHosts(pubkeys[:]...); err != nil {
+	if _, err := e.ScanHosts(context.Background(), pubkeys[:]...); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Removes the context and context cancel func on the explorer struct in favor of the more idiomatic threadgroup.