### PR TITLE
Fix storage proof retrieval issue from refactor

### DIFF
--- a/internal/testutil/check.go
+++ b/internal/testutil/check.go
@@ -95,6 +95,16 @@ func CheckTransaction(t *testing.T, expectTxn types.Transaction, gotTxn explorer
 		Equal(t, "miner fee", expectTxn.MinerFees[i], gotTxn.MinerFees[i])
 	}
 
+	Equal(t, "storage proofs", len(expectTxn.StorageProofs), len(gotTxn.StorageProofs))
+	for i := range expectTxn.StorageProofs {
+		expected := expectTxn.StorageProofs[i]
+		got := gotTxn.StorageProofs[i]
+
+		Equal(t, "parent ID", expected.ParentID, got.ParentID)
+		Equal(t, "leaf", expected.Leaf, got.Leaf)
+		Equal(t, "parent ID", expected.Proof, got.Proof)
+	}
+
 	Equal(t, "signatures", len(expectTxn.Signatures), len(gotTxn.Signatures))
 	for i := range expectTxn.Signatures {
 		expected := expectTxn.Signatures[i]

--- a/persist/sqlite/transactions.go
+++ b/persist/sqlite/transactions.go
@@ -427,7 +427,7 @@ ORDER BY ts.transaction_order ASC`)
 
 // decorateStorageProofs returns the storage proofs for each transaction.
 func decorateStorageProofs(tx *txn, dbIDs []int64, txns []explorer.Transaction) error {
-	stmt, err := tx.Prepare(`SELECT transaction_id, parent_id, leaf, proof
+	stmt, err := tx.Prepare(`SELECT parent_id, leaf, proof
 FROM transaction_storage_proofs
 WHERE transaction_id = ?
 ORDER BY transaction_order ASC`)


### PR DESCRIPTION
In https://github.com/SiaFoundation/explored/pull/218 I accidentally left an extra column in a query that was a part of the refactored `decorateStorageProofs`.  This corrects that and adds a test that simply retrieves a transaction with a storage proof in it after it has been mined and checks that it matches the original transaction.  All other transaction fields besides storage proofs are checked at some point in other tests which is why this wasn't caught in #218. Some fixes were required to properly update the chain store as well in the `testChain` we use in the new tests.  I wanted to make this a quick fix since a PR where we fully handle contracts and resolved/valid states would probably take a while to review and implement feedback.