### PR TITLE
Fix file contract revert resolved state bug

### DIFF
--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -745,20 +745,20 @@ func deleteBlock(tx *txn, bid types.BlockID) error {
 }
 
 func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b types.Block, fces []explorer.FileContractUpdate) (map[explorer.DBFileContract]int64, error) {
-	stmt, err := tx.Prepare(`INSERT INTO file_contract_elements(contract_id, block_id, transaction_id, leaf_index, resolved, valid, filesize, file_merkle_root, window_start, window_end, payout, unlock_hash, revision_number)
-        VALUES (?, ?, ?, ?, FALSE, FALSE, ?, ?, ?, ?, ?, ?, ?)
+	stmt, err := tx.Prepare(`INSERT INTO file_contract_elements(contract_id, block_id, transaction_id, leaf_index, filesize, file_merkle_root, window_start, window_end, payout, unlock_hash, revision_number)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (contract_id, revision_number)
-        DO UPDATE SET resolved = ?, valid = ?, leaf_index = ?
+        DO UPDATE SET leaf_index = ?
         RETURNING id;`)
 	if err != nil {
 		return nil, fmt.Errorf("updateFileContractElements: failed to prepare main statement: %w", err)
 	}
 	defer stmt.Close()
 
-	revisionStmt, err := tx.Prepare(`INSERT INTO last_contract_revision(contract_id, contract_element_id, ed25519_renter_key, ed25519_host_key, confirmation_height, confirmation_block_id, confirmation_transaction_id)
-    VALUES (?, ?, ?, ?, COALESCE(?, X''), COALESCE(?, X''), COALESCE(?, X''))
+	revisionStmt, err := tx.Prepare(`INSERT INTO last_contract_revision(contract_id, contract_element_id, resolved, valid, ed25519_renter_key, ed25519_host_key, confirmation_height, confirmation_block_id, confirmation_transaction_id)
+    VALUES (?, ?, ?, ?, ?, ?, COALESCE(?, X''), COALESCE(?, X''), COALESCE(?, X''))
     ON CONFLICT (contract_id)
-    DO UPDATE SET contract_element_id = ?, ed25519_renter_key = COALESCE(?, ed25519_renter_key), ed25519_host_key = COALESCE(?, ed25519_host_key), confirmation_height = COALESCE(?, confirmation_height), confirmation_block_id = COALESCE(?, confirmation_block_id), confirmation_transaction_id = COALESCE(?, confirmation_transaction_id)`)
+    DO UPDATE SET resolved = EXCLUDED.resolved, valid = EXCLUDED.valid, contract_element_id = ?, ed25519_renter_key = COALESCE(?, ed25519_renter_key), ed25519_host_key = COALESCE(?, ed25519_host_key), confirmation_height = COALESCE(?, confirmation_height), confirmation_block_id = COALESCE(?, confirmation_block_id), confirmation_transaction_id = COALESCE(?, confirmation_transaction_id)`)
 	if err != nil {
 		return nil, fmt.Errorf("updateFileContractElements: failed to prepare last_contract_revision statement: %w", err)
 	}
@@ -829,7 +829,7 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
 	addFC := func(fcID types.FileContractID, leafIndex uint64, fc types.FileContract, confirmationTransactionID *types.TransactionID, resolved, valid, lastRevision bool) error {
 		var dbID int64
 		dbFC := explorer.DBFileContract{ID: fcID, RevisionNumber: fc.RevisionNumber}
-		err := stmt.QueryRow(encode(fcID), encode(index.ID), encode(fcTxns[dbFC]), encode(leafIndex), encode(fc.Filesize), encode(fc.FileMerkleRoot), encode(fc.WindowStart), encode(fc.WindowEnd), encode(fc.Payout), encode(fc.UnlockHash), encode(fc.RevisionNumber), resolved, valid, encode(leafIndex)).Scan(&dbID)
+		err := stmt.QueryRow(encode(fcID), encode(index.ID), encode(fcTxns[dbFC]), encode(leafIndex), encode(fc.Filesize), encode(fc.FileMerkleRoot), encode(fc.WindowStart), encode(fc.WindowEnd), encode(fc.Payout), encode(fc.UnlockHash), encode(fc.RevisionNumber), encode(leafIndex)).Scan(&dbID)
 		if err != nil {
 			return fmt.Errorf("failed to execute file_contract_elements statement: %w", err)
 		}
@@ -861,7 +861,7 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
 				encodedConfirmationTransactionID = encode(*confirmationTransactionID).([]byte)
 			}
 
-			if _, err := revisionStmt.Exec(encode(fcID), dbID, encodedRenterKey, encodedHostKey, encodedHeight, encodedBlockID, encodedConfirmationTransactionID, dbID, encodedRenterKey, encodedHostKey, encodedHeight, encodedBlockID, encodedConfirmationTransactionID); err != nil {
+			if _, err := revisionStmt.Exec(encode(fcID), dbID, resolved, valid, encodedRenterKey, encodedHostKey, encodedHeight, encodedBlockID, encodedConfirmationTransactionID, dbID, encodedRenterKey, encodedHostKey, encodedHeight, encodedBlockID, encodedConfirmationTransactionID); err != nil {
 				return fmt.Errorf("failed to update last revision number: %w", err)
 			}
 		}
@@ -883,8 +883,17 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
 			} else {
 				// Contract formation reverted.
 				// The contract update has no revision, therefore it refers
-				// to the original contract formation.
-				continue
+				// to the original contract formation. There still may be
+				// resolved/valid state to update, so we still need to readd
+				// the contract.
+				fce = &update.FileContractElement
+			}
+
+			if update.Resolved {
+				update.Resolved = false
+			}
+			if update.Valid {
+				update.Valid = false
 			}
 		} else {
 			// Applying

--- a/persist/sqlite/consensus_refactored_test.go
+++ b/persist/sqlite/consensus_refactored_test.go
@@ -255,6 +255,9 @@ func (n *testChain) assertFCE(t *testing.T, fcID types.FileContractID, expected 
 	testutil.Equal(t, "ExtendedFileContract", expected, fce)
 }
 
+// assertTransactionContracts asserts that the enhanced FileContracts
+// (revisions = false) or FileContractRevisions (revisions = true) in a
+// transaction retrieved from the explorer match the expected contracts.
 func (n *testChain) assertTransactionContracts(t *testing.T, txnID types.TransactionID, revisions bool, expected ...explorer.ExtendedFileContract) {
 	txns, err := n.db.Transactions([]types.TransactionID{txnID})
 	if err != nil {

--- a/persist/sqlite/consensus_refactored_test.go
+++ b/persist/sqlite/consensus_refactored_test.go
@@ -1458,7 +1458,7 @@ func TestFileContractValid(t *testing.T) {
 	tip := n.tipState().Index
 	txnID := txn2.ID()
 
-	// should be resovled
+	// should be resolved
 	fceResolved := fce
 	fceResolved.Resolved = true
 	fceResolved.Valid = true
@@ -1474,15 +1474,22 @@ func TestFileContractValid(t *testing.T) {
 	n.assertFCE(t, fce.ID, fce)
 	n.assertTransactionContracts(t, txn1.ID(), false, fce)
 
-	// FCE should not exist
 	n.revertBlock(t)
 
+	// FCE should not exist
 	{
 		fces, err := n.db.Contracts([]types.FileContractID{fce.ID})
 		if err != nil {
 			t.Fatal(err)
 		}
 		testutil.Equal(t, "len(fces)", 0, len(fces))
+	}
+
+	{
+		_, err := n.db.ContractRevisions(fce.ID)
+		if !errors.Is(err, explorer.ErrContractNotFound) {
+			t.Fatal("should have got contract not found error for reverted contract:", err)
+		}
 	}
 }
 
@@ -1535,14 +1542,21 @@ func TestFileContractMissed(t *testing.T) {
 	n.assertFCE(t, fce.ID, fce)
 	n.assertTransactionContracts(t, txn1.ID(), false, fce)
 
-	// FCE should not exist
 	n.revertBlock(t)
 
+	// FCE should not exist
 	{
 		fces, err := n.db.Contracts([]types.FileContractID{fce.ID})
 		if err != nil {
 			t.Fatal(err)
 		}
 		testutil.Equal(t, "len(fces)", 0, len(fces))
+	}
+
+	{
+		_, err := n.db.ContractRevisions(fce.ID)
+		if !errors.Is(err, explorer.ErrContractNotFound) {
+			t.Fatal("should have got contract not found error for reverted contract:", err)
+		}
 	}
 }

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -42,7 +42,7 @@ func scanFileContract(tx *txn, s scanner) (fc explorer.ExtendedFileContract, err
 // Contracts implements explorer.Store.
 func (s *Store) Contracts(ids []types.FileContractID) (result []explorer.ExtendedFileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		query := `SELECT fc1.id, fc1.contract_id, fc1.resolved, fc1.valid, fc1.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc1.filesize, fc1.file_merkle_root, fc1.window_start, fc1.window_end, fc1.payout, fc1.unlock_hash, fc1.revision_number
+		query := `SELECT fc1.id, fc1.contract_id, rev.resolved, rev.valid, fc1.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc1.filesize, fc1.file_merkle_root, fc1.window_start, fc1.window_end, fc1.payout, fc1.unlock_hash, fc1.revision_number
 			FROM file_contract_elements fc1
 			INNER JOIN last_contract_revision rev ON rev.contract_element_id = fc1.id
 			WHERE rev.contract_id IN (` + queryPlaceHolders(len(ids)) + `)`
@@ -69,7 +69,7 @@ func (s *Store) Contracts(ids []types.FileContractID) (result []explorer.Extende
 // ContractRevisions implements explorer.Store.
 func (s *Store) ContractRevisions(id types.FileContractID) (revisions []explorer.ExtendedFileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		query := `SELECT fc.id, fc.contract_id, fc.resolved, fc.valid, fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
+		query := `SELECT fc.id, fc.contract_id, rev.resolved, rev.valid, fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
 			FROM file_contract_elements fc
 			JOIN last_contract_revision rev ON rev.contract_id = fc.contract_id
 			WHERE fc.contract_id = ?
@@ -99,7 +99,7 @@ func (s *Store) ContractRevisions(id types.FileContractID) (revisions []explorer
 // ContractsKey implements explorer.Store.
 func (s *Store) ContractsKey(key types.PublicKey) (result []explorer.ExtendedFileContract, err error) {
 	err = s.transaction(func(tx *txn) error {
-		query := `SELECT fc1.id, fc1.contract_id, fc1.resolved, fc1.valid, fc1.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc1.filesize, fc1.file_merkle_root, fc1.window_start, fc1.window_end, fc1.payout, fc1.unlock_hash, fc1.revision_number
+		query := `SELECT fc1.id, fc1.contract_id, rev.resolved, rev.valid, fc1.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc1.filesize, fc1.file_merkle_root, fc1.window_start, fc1.window_end, fc1.payout, fc1.unlock_hash, fc1.revision_number
 			FROM file_contract_elements fc1
 			INNER JOIN last_contract_revision rev ON rev.contract_element_id = fc1.id
 			WHERE rev.ed25519_renter_key = ? OR rev.ed25519_host_key = ?`

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -86,9 +86,6 @@ CREATE TABLE file_contract_elements (
 	contract_id BLOB NOT NULL,
 	leaf_index BLOB NOT NULL,
 
-	resolved INTEGER NOT NULL,
-	valid INTEGER NOT NULL,
-
 	filesize BLOB NOT NULL,
 	file_merkle_root BLOB NOT NULL,
 	window_start BLOB NOT NULL,
@@ -102,6 +99,9 @@ CREATE INDEX file_contract_elements_contract_id_revision_number_index ON file_co
 
 CREATE TABLE last_contract_revision (
 	contract_id BLOB PRIMARY KEY NOT NULL,
+
+	resolved INTEGER NOT NULL,
+	valid INTEGER NOT NULL,
 
 	ed25519_renter_key BLOB,
 	ed25519_host_key BLOB,

--- a/persist/sqlite/transactions.go
+++ b/persist/sqlite/transactions.go
@@ -337,7 +337,7 @@ ORDER BY contract_order ASC`, contractID)
 
 // decorateFileContracts returns the file contracts for each transaction.
 func decorateFileContracts(tx *txn, dbIDs []int64, txns []explorer.Transaction) error {
-	stmt, err := tx.Prepare(`SELECT fc.id, fc.contract_id, fc.resolved, fc.valid, fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
+	stmt, err := tx.Prepare(`SELECT fc.id, fc.contract_id, rev.resolved, rev.valid, fc.transaction_id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
 FROM file_contract_elements fc
 INNER JOIN transaction_file_contracts ts ON ts.contract_id = fc.id
 INNER JOIN last_contract_revision rev ON rev.contract_id = fc.contract_id
@@ -374,7 +374,7 @@ ORDER BY ts.transaction_order ASC`)
 
 // decorateFileContractRevisions returns the file contract revisions for each transaction.
 func decorateFileContractRevisions(tx *txn, dbIDs []int64, txns []explorer.Transaction) error {
-	stmt, err := tx.Prepare(`SELECT fc.id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, ts.parent_id, ts.unlock_conditions, fc.contract_id, fc.resolved, fc.valid, fc.transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
+	stmt, err := tx.Prepare(`SELECT fc.id, rev.confirmation_height, rev.confirmation_block_id, rev.confirmation_transaction_id, rev.proof_height, rev.proof_block_id, rev.proof_transaction_id, ts.parent_id, ts.unlock_conditions, fc.contract_id, rev.resolved, rev.valid, fc.transaction_id, fc.filesize, fc.file_merkle_root, fc.window_start, fc.window_end, fc.payout, fc.unlock_hash, fc.revision_number
 FROM file_contract_elements fc
 INNER JOIN transaction_file_contract_revisions ts ON ts.contract_id = fc.id
 INNER JOIN last_contract_revision rev ON rev.contract_id = fc.contract_id


### PR DESCRIPTION
- Fix bug where resolved/valid state were not reset after revert.  The code in `updateFileContractElements` failed to account for the fact that if we are reverting and the contract is resolved or valid in the file contract element diff from core, then we should do the opposite and set those to false.
- Move resolved/valid state to the `last_contract_revision` table from `file_contract_elements`.  Before, when we retrieved a transaction that created or revised a file contract, in the enhanced `explorer.ExtendedFileContract` struct the resolved/valid fields would reflect whether it was resolved/valid at the time of that transaction.  This is not really useful, so it makes more sense to have those values reflect the latest state.  This is also in line with how we handle resolution state for v2 contracts.
- Add basic tests for file contracts