### PR TITLE
Revert "update core and coreutils"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/oschwald/geoip2-golang v1.11.0
-	go.sia.tech/core v0.12.4-0.20250521182943-a92c180cba68
-	go.sia.tech/coreutils v0.13.7-0.20250521183059-f24efe3a041c
+	go.sia.tech/core v0.12.3
+	go.sia.tech/coreutils v0.13.6
 	go.sia.tech/jape v0.14.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842

--- a/go.sum
+++ b/go.sum
@@ -45,10 +45,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
 go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
-go.sia.tech/core v0.12.4-0.20250521182943-a92c180cba68 h1:MpWF7B+0E+dBzTffdPr/G/6ChL4hImhGrY330QC4Pqg=
-go.sia.tech/core v0.12.4-0.20250521182943-a92c180cba68/go.mod h1:woUSWQdrRFXkYdk2g2532rguQ1EyMU+2/kcC4JnHSx4=
-go.sia.tech/coreutils v0.13.7-0.20250521183059-f24efe3a041c h1:tAE6TK/vAC+Lcjv+fejYUfb1eHR8WTvJ7rGvsFh2bdw=
-go.sia.tech/coreutils v0.13.7-0.20250521183059-f24efe3a041c/go.mod h1:llsSYuMOSYZxTUbctYLyRw8RlfxpUH9+ClK0Z5vrfJM=
+go.sia.tech/core v0.12.3 h1:p0BfsKfc7jVRKRDm2K9udxqBEqIGU0An54vP4WL+SH8=
+go.sia.tech/core v0.12.3/go.mod h1:woUSWQdrRFXkYdk2g2532rguQ1EyMU+2/kcC4JnHSx4=
+go.sia.tech/coreutils v0.13.6 h1:RNCrMRO2QA0f/0OMlV5ULjyKYK1KUH1qN0zu/SLvIQk=
+go.sia.tech/coreutils v0.13.6/go.mod h1:JR8onVt1R9wz4kg/bzyGg75HuZyTbBVmt3OKcUac6Qo=
 go.sia.tech/jape v0.14.0 h1:hyocTKqvcji+rC1vDE1djINlpErQQVDS6zoLMmxW3Xs=
 go.sia.tech/jape v0.14.0/go.mod h1:tONxoKrNr0iQWzBCygwlTkGoGjuEhyVpLGInvGd2mGY=
 go.sia.tech/mux v1.4.0 h1:LgsLHtn7l+25MwrgaPaUCaS8f2W2/tfvHIdXps04sVo=

--- a/internal/testutil/chain.go
+++ b/internal/testutil/chain.go
@@ -115,7 +115,7 @@ func MineV2Block(state consensus.State, txns []types.V2Transaction, minerAddr ty
 			Height:       state.Index.Height + 1,
 		},
 	}
-	b.V2.Commitment = state.Commitment(b.MinerPayouts[0].Address, b.Transactions, b.V2Transactions())
+	b.V2.Commitment = state.Commitment(state.TransactionsCommitment(b.Transactions, b.V2Transactions()), b.MinerPayouts[0].Address)
 	for b.ID().CmpWork(state.ChildTarget) < 0 {
 		b.Nonce += state.NonceFactor()
 	}


### PR DESCRIPTION
Reverts SiaFoundation/explored#236 to make sure zen.siascan.com is consistent with its zen wallet for exchanges using it for testing.