### PR TITLE
Add basic benchmarks for outputs, unspent outputs, and transactions

### DIFF
--- a/internal/testutil/check.go
+++ b/internal/testutil/check.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Equal checks if two values of the same type are equal and fails otherwise.
-func Equal[T any](t *testing.T, desc string, expected, got T) {
+func Equal[T any](t testing.TB, desc string, expected, got T) {
 	t.Helper()
 
 	options := cmp.Options([]cmp.Option{
@@ -30,7 +30,7 @@ func Equal[T any](t *testing.T, desc string, expected, got T) {
 
 // CheckTransaction checks the inputs and outputs of the retrieved transaction
 // with the source transaction.
-func CheckTransaction(t *testing.T, expectTxn types.Transaction, gotTxn explorer.Transaction) {
+func CheckTransaction(t testing.TB, expectTxn types.Transaction, gotTxn explorer.Transaction) {
 	t.Helper()
 
 	Equal(t, "siacoin inputs", len(expectTxn.SiacoinInputs), len(gotTxn.SiacoinInputs))
@@ -134,7 +134,7 @@ func CheckTransaction(t *testing.T, expectTxn types.Transaction, gotTxn explorer
 
 // CheckV2Transaction checks the inputs and outputs of the retrieved transaction
 // with the source transaction.
-func CheckV2Transaction(t *testing.T, expectTxn types.V2Transaction, gotTxn explorer.V2Transaction) {
+func CheckV2Transaction(t testing.TB, expectTxn types.V2Transaction, gotTxn explorer.V2Transaction) {
 	t.Helper()
 
 	// checkV2FC checks the retrieved file contract with the source file contract

--- a/persist/sqlite/addresses.go
+++ b/persist/sqlite/addresses.go
@@ -223,7 +223,6 @@ func getSiafundElements(tx *txn, ids []types.SiafundOutputID, includeProof bool)
 		}
 	}
 	return
-
 }
 
 // SiacoinElements implements explorer.Store.

--- a/persist/sqlite/consensus_refactored_test.go
+++ b/persist/sqlite/consensus_refactored_test.go
@@ -2666,52 +2666,11 @@ func BenchmarkTransactions(b *testing.B) {
 }
 
 func BenchmarkSiacoinOutputs(b *testing.B) {
-	pk1 := types.GeneratePrivateKey()
-	uc1 := types.StandardUnlockConditions(pk1.PublicKey())
-	addr1 := uc1.UnlockHash()
-
-	pk2 := types.GeneratePrivateKey()
-	uc2 := types.StandardUnlockConditions(pk2.PublicKey())
-	addr2 := uc2.UnlockHash()
-
-	pk3 := types.GeneratePrivateKey()
-	uc3 := types.StandardUnlockConditions(pk3.PublicKey())
-	addr3 := uc3.UnlockHash()
-
-	n := newTestChain(b, false, func(network *consensus.Network, genesisBlock types.Block) {
-		genesisBlock.Transactions[0].SiacoinOutputs[0].Address = addr1
-	})
-	genesisTxn := n.genesis().Transactions[0]
-
-	txn1 := types.Transaction{
-		SiacoinInputs: []types.SiacoinInput{{
-			ParentID:         genesisTxn.SiacoinOutputID(0),
-			UnlockConditions: uc1,
-		}},
-		SiacoinOutputs: func() (result []types.SiacoinOutput) {
-			val := genesisTxn.SiacoinOutputs[0].Value
-			// send 1000 small outputs to addr2
-			for range 1000 {
-				amount := types.NewCurrency64(1)
-				result = append(result, types.SiacoinOutput{
-					Address: addr2,
-					Value:   amount,
-				})
-				val = val.Sub(amount)
-			}
-			// send change to addr3
-			result = append(result, types.SiacoinOutput{
-				Address: addr3,
-				Value:   val,
-			})
-			return
-		}(),
-	}
-	testutil.SignTransaction(n.tipState(), pk1, &txn1)
-
-	n.mineTransactions(b, txn1)
+	addr1 := types.StandardUnlockConditions(types.GeneratePrivateKey().PublicKey()).UnlockHash()
+	n := newTestChain(b, false, nil)
 
 	// add a bunch of random outputs
+	var ids []types.SiacoinOutputID
 	err := n.db.transaction(func(tx *txn) error {
 		stmt, err := tx.Prepare(`INSERT INTO siacoin_elements(block_id, output_id, leaf_index, spent_index, source, maturity_height, address, value) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
 		if err != nil {
@@ -2721,15 +2680,18 @@ func BenchmarkSiacoinOutputs(b *testing.B) {
 		spentIndex := encode(n.tipState().Index)
 		bid := encode(n.tipState().Index.ID)
 		val := encode(types.NewCurrency64(1))
+
 		var addr types.Address
-		for i := range 5_000_000 {
+		for i := range 1_000_000 {
 			if i%100_000 == 0 {
 				b.Log("Inserted siacoin element:", i)
 			}
-			var oid types.SiacoinOutputID
-			frand.Read(oid[:])
 
-			// label half of inputs spent
+			var scID types.SiacoinOutputID
+			frand.Read(scID[:])
+			ids = append(ids, scID)
+
+			// label half of elements spent
 			var spent any
 			if i%2 == 0 {
 				spent = spentIndex
@@ -2738,7 +2700,23 @@ func BenchmarkSiacoinOutputs(b *testing.B) {
 			if i%3 == 0 {
 				frand.Read(addr[:])
 			}
-			if _, err := stmt.Exec(bid, encode(oid), encode(uint64(0)), spent, explorer.SourceTransaction, frand.Uint64n(144), encode(addr), val); err != nil {
+			if _, err := stmt.Exec(bid, encode(scID), encode(uint64(0)), spent, explorer.SourceTransaction, frand.Uint64n(144), encode(addr), val); err != nil {
+				return err
+			}
+		}
+
+		// give addr1 2000 outputs, 1000 of which are spent
+		for i := range 2000 {
+			// label half of elements spent
+			var spent any
+			if i%2 == 0 {
+				spent = spentIndex
+			}
+
+			var scID types.SiacoinOutputID
+			frand.Read(scID[:])
+
+			if _, err := stmt.Exec(bid, encode(scID), encode(uint64(0)), spent, explorer.SourceTransaction, 0, encode(addr1), val); err != nil {
 				return err
 			}
 		}
@@ -2748,44 +2726,46 @@ func BenchmarkSiacoinOutputs(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+
 	unspentBenchmarks := []struct {
-		name   string
-		addr   types.Address
-		offset uint64
+		limit uint64
 	}{
-		{"addr1 (no unspent outputs)", addr1, 0},
-		{"addr2 (unspent outputs 0-99)", addr2, 0},
-		{"addr2 (unspent outputs 100-199)", addr2, 100},
-		{"addr3 (unspent output 0)", addr3, 0},
+		{10},
+		{100},
+		{1000},
 	}
 	b.ResetTimer()
 	for _, bm := range unspentBenchmarks {
-		b.Run(bm.name, func(b *testing.B) {
+		b.Run(strconv.FormatUint(bm.limit, 10)+" unspent outputs", func(b *testing.B) {
+			offset := frand.Uint64n(1000 - bm.limit + 1)
 			for range b.N {
-				_, err := n.db.UnspentSiacoinOutputs(bm.addr, bm.offset, 100)
+				sces, err := n.db.UnspentSiacoinOutputs(addr1, offset, bm.limit)
 				if err != nil {
 					b.Fatal(err)
 				}
+				testutil.Equal(b, "len(sces)", bm.limit, uint64(len(sces)))
 			}
 		})
 	}
 
-	elementBenchmarks := []struct {
-		name string
-		id   types.SiacoinOutputID
+	benchmarks := []struct {
+		limit int
 	}{
-		{"genesis output (spent)", genesisTxn.SiacoinOutputID(0)},
-		{"txn1 change output (unspent)", txn1.SiacoinOutputID(len(txn1.SiacoinOutputs) - 1)},
+		{10},
+		{100},
+		{1000},
 	}
 	b.ResetTimer()
-	for _, bm := range elementBenchmarks {
-		b.Run(bm.name, func(b *testing.B) {
-			scIDs := []types.SiacoinOutputID{bm.id}
+	for _, bm := range benchmarks {
+		b.Run(strconv.Itoa(bm.limit)+" siacoin elements", func(b *testing.B) {
+			offset := frand.Intn(len(ids) - bm.limit)
+			scIDs := ids[offset : offset+bm.limit]
 			for range b.N {
-				_, err := n.db.SiacoinElements(scIDs)
+				sces, err := n.db.SiacoinElements(scIDs)
 				if err != nil {
 					b.Fatal(err)
 				}
+				testutil.Equal(b, "len(sces)", bm.limit, len(sces))
 			}
 		})
 	}

--- a/persist/sqlite/consensus_refactored_test.go
+++ b/persist/sqlite/consensus_refactored_test.go
@@ -2737,7 +2737,6 @@ func BenchmarkSiacoinOutputs(b *testing.B) {
 	})
 	genesisTxn := n.genesis().Transactions[0]
 
-	b.ResetTimer()
 	txn1 := types.Transaction{
 		SiacoinInputs: []types.SiacoinInput{{
 			ParentID:         genesisTxn.SiacoinOutputID(0),

--- a/persist/sqlite/consensus_refactored_test.go
+++ b/persist/sqlite/consensus_refactored_test.go
@@ -30,7 +30,7 @@ type testChain struct {
 	states      []consensus.State
 }
 
-func newTestChain(t *testing.T, v2 bool, modifyGenesis func(*consensus.Network, types.Block)) *testChain {
+func newTestChain(t testing.TB, v2 bool, modifyGenesis func(*consensus.Network, types.Block)) *testChain {
 	log := zaptest.NewLogger(t)
 	dir := t.TempDir()
 
@@ -95,7 +95,7 @@ func (n *testChain) tipState() consensus.State {
 	return n.states[len(n.states)-1]
 }
 
-func (n *testChain) applyBlock(t *testing.T, b types.Block) {
+func (n *testChain) applyBlock(t testing.TB, b types.Block) {
 	t.Helper()
 
 	cs := n.tipState()
@@ -125,7 +125,7 @@ func (n *testChain) applyBlock(t *testing.T, b types.Block) {
 	n.states = append(n.states, cs)
 }
 
-func (n *testChain) revertBlock(t *testing.T) {
+func (n *testChain) revertBlock(t testing.TB) {
 	b := n.blocks[len(n.blocks)-1]
 	bs := n.supplements[len(n.supplements)-1]
 	prevState := n.states[len(n.states)-2]
@@ -146,14 +146,14 @@ func (n *testChain) revertBlock(t *testing.T) {
 	n.states = n.states[:len(n.states)-1]
 }
 
-func (n *testChain) mineTransactions(t *testing.T, txns ...types.Transaction) {
+func (n *testChain) mineTransactions(t testing.TB, txns ...types.Transaction) {
 	t.Helper()
 
 	b := testutil.MineBlock(n.tipState(), txns, types.VoidAddress)
 	n.applyBlock(t, b)
 }
 
-func (n *testChain) assertTransactions(t *testing.T, expected ...types.Transaction) {
+func (n *testChain) assertTransactions(t testing.TB, expected ...types.Transaction) {
 	t.Helper()
 
 	for _, txn := range expected {
@@ -167,7 +167,7 @@ func (n *testChain) assertTransactions(t *testing.T, expected ...types.Transacti
 	}
 }
 
-func (n *testChain) assertChainIndices(t *testing.T, txnID types.TransactionID, expected ...types.ChainIndex) {
+func (n *testChain) assertChainIndices(t testing.TB, txnID types.TransactionID, expected ...types.ChainIndex) {
 	t.Helper()
 
 	indices, err := n.db.TransactionChainIndices(txnID, 0, math.MaxInt64)
@@ -183,7 +183,7 @@ func (n *testChain) assertChainIndices(t *testing.T, txnID types.TransactionID, 
 }
 
 // assertSCE asserts the Siacoin element in the db has the right source, index and output
-func (n *testChain) assertSCE(t *testing.T, scID types.SiacoinOutputID, index *types.ChainIndex, sco types.SiacoinOutput) {
+func (n *testChain) assertSCE(t testing.TB, scID types.SiacoinOutputID, index *types.ChainIndex, sco types.SiacoinOutput) {
 	t.Helper()
 
 	sces, err := n.db.SiacoinElements([]types.SiacoinOutputID{scID})
@@ -199,7 +199,7 @@ func (n *testChain) assertSCE(t *testing.T, scID types.SiacoinOutputID, index *t
 }
 
 // assertSFE asserts the Siafund element in the db has the right source, index and output
-func (n *testChain) assertSFE(t *testing.T, sfID types.SiafundOutputID, index *types.ChainIndex, sfo types.SiafundOutput) {
+func (n *testChain) assertSFE(t testing.TB, sfID types.SiafundOutputID, index *types.ChainIndex, sfo types.SiafundOutput) {
 	t.Helper()
 
 	sfes, err := n.db.SiafundElements([]types.SiafundOutputID{sfID})
@@ -215,7 +215,7 @@ func (n *testChain) assertSFE(t *testing.T, sfID types.SiafundOutputID, index *t
 
 // assertFCE asserts the contract element in the db has the right state and
 // block/transaction indices
-func (n *testChain) assertFCE(t *testing.T, fcID types.FileContractID, expected explorer.ExtendedFileContract) {
+func (n *testChain) assertFCE(t testing.TB, fcID types.FileContractID, expected explorer.ExtendedFileContract) {
 	t.Helper()
 
 	fces, err := n.db.Contracts([]types.FileContractID{fcID})
@@ -234,7 +234,7 @@ func (n *testChain) assertFCE(t *testing.T, fcID types.FileContractID, expected 
 // assertTransactionContracts asserts that the enhanced FileContracts
 // (revisions = false) or FileContractRevisions (revisions = true) in a
 // transaction retrieved from the explorer match the expected contracts.
-func (n *testChain) assertTransactionContracts(t *testing.T, txnID types.TransactionID, revisions bool, expected ...explorer.ExtendedFileContract) {
+func (n *testChain) assertTransactionContracts(t testing.TB, txnID types.TransactionID, revisions bool, expected ...explorer.ExtendedFileContract) {
 	t.Helper()
 
 	txns, err := n.db.Transactions([]types.TransactionID{txnID})
@@ -257,7 +257,7 @@ func (n *testChain) assertTransactionContracts(t *testing.T, txnID types.Transac
 	}
 }
 
-func (n *testChain) assertContractRevisions(t *testing.T, fcID types.FileContractID, expected ...explorer.ExtendedFileContract) {
+func (n *testChain) assertContractRevisions(t testing.TB, fcID types.FileContractID, expected ...explorer.ExtendedFileContract) {
 	t.Helper()
 
 	fces, err := n.db.ContractRevisions(fcID)
@@ -276,7 +276,7 @@ func (n *testChain) assertContractRevisions(t *testing.T, fcID types.FileContrac
 	}
 }
 
-func (n *testChain) assertEvents(t *testing.T, addr types.Address, expected ...explorer.Event) {
+func (n *testChain) assertEvents(t testing.TB, addr types.Address, expected ...explorer.Event) {
 	t.Helper()
 
 	events, err := n.db.AddressEvents(addr, 0, math.MaxInt64)
@@ -303,7 +303,7 @@ func (n *testChain) assertEvents(t *testing.T, addr types.Address, expected ...e
 	}
 }
 
-func (n *testChain) getSCE(t *testing.T, scID types.SiacoinOutputID) explorer.SiacoinOutput {
+func (n *testChain) getSCE(t testing.TB, scID types.SiacoinOutputID) explorer.SiacoinOutput {
 	t.Helper()
 
 	sces, err := n.db.SiacoinElements([]types.SiacoinOutputID{scID})
@@ -316,7 +316,7 @@ func (n *testChain) getSCE(t *testing.T, scID types.SiacoinOutputID) explorer.Si
 	return sces[0]
 }
 
-func (n *testChain) getFCE(t *testing.T, fcID types.FileContractID) explorer.ExtendedFileContract {
+func (n *testChain) getFCE(t testing.TB, fcID types.FileContractID) explorer.ExtendedFileContract {
 	t.Helper()
 
 	fces, err := n.db.Contracts([]types.FileContractID{fcID})
@@ -328,7 +328,7 @@ func (n *testChain) getFCE(t *testing.T, fcID types.FileContractID) explorer.Ext
 	return fces[0]
 }
 
-func (n *testChain) getTxn(t *testing.T, txnID types.TransactionID) explorer.Transaction {
+func (n *testChain) getTxn(t testing.TB, txnID types.TransactionID) explorer.Transaction {
 	t.Helper()
 
 	txns, err := n.db.Transactions([]types.TransactionID{txnID})
@@ -354,7 +354,7 @@ func prepareContract(addr types.Address, endHeight uint64) types.FileContract {
 	return fc
 }
 
-func (n *testChain) assertBlock(t *testing.T, cs consensus.State, block types.Block) {
+func (n *testChain) assertBlock(t testing.TB, cs consensus.State, block types.Block) {
 	got, err := n.db.Block(block.ID())
 	if err != nil {
 		t.Fatal(err)
@@ -2555,4 +2555,123 @@ func TestHostScan(t *testing.T) {
 	host1.FailedInteractions++
 
 	assertHost(hosts[0].PublicKey, host1)
+}
+
+func BenchmarkTransactions(b *testing.B) {
+	pk1 := types.GeneratePrivateKey()
+	uc1 := types.StandardUnlockConditions(pk1.PublicKey())
+	addr1 := uc1.UnlockHash()
+
+	n := newTestChain(b, false, func(network *consensus.Network, genesisBlock types.Block) {
+		genesisBlock.Transactions[0].SiacoinOutputs[0].Address = addr1
+	})
+	val := n.genesis().Transactions[0].SiacoinOutputs[0].Value
+
+	txn1 := types.Transaction{}
+
+	txn2 := types.Transaction{ArbitraryData: [][]byte{{0, 1, 2, 3}}}
+
+	fc := prepareContract(addr1, n.tipState().Index.Height+1)
+	txn3 := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{{
+			ParentID:         n.genesis().Transactions[0].SiacoinOutputID(0),
+			UnlockConditions: uc1,
+		}},
+		SiacoinOutputs: []types.SiacoinOutput{{
+			Address: addr1,
+			Value:   val.Sub(fc.Payout),
+		}},
+		FileContracts: []types.FileContract{fc},
+	}
+	testutil.SignTransaction(n.tipState(), pk1, &txn3)
+
+	n.mineTransactions(b, txn1, txn2, txn3)
+
+	benchmarks := []struct {
+		name  string
+		txnID types.TransactionID
+	}{
+		{"empty transaction", txn1.ID()},
+		{"transaction with only arbitrary data", txn2.ID()},
+		{"file contract formation transaction", txn3.ID()},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			txnIDs := []types.TransactionID{bm.txnID}
+			for range b.N {
+				_, err := n.db.Transactions(txnIDs)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnspentSiacoinOutputs(b *testing.B) {
+	pk1 := types.GeneratePrivateKey()
+	uc1 := types.StandardUnlockConditions(pk1.PublicKey())
+	addr1 := uc1.UnlockHash()
+
+	pk2 := types.GeneratePrivateKey()
+	uc2 := types.StandardUnlockConditions(pk2.PublicKey())
+	addr2 := uc2.UnlockHash()
+
+	pk3 := types.GeneratePrivateKey()
+	uc3 := types.StandardUnlockConditions(pk3.PublicKey())
+	addr3 := uc3.UnlockHash()
+
+	n := newTestChain(b, false, func(network *consensus.Network, genesisBlock types.Block) {
+		genesisBlock.Transactions[0].SiacoinOutputs[0].Address = addr1
+	})
+	genesisTxn := n.genesis().Transactions[0]
+
+	txn1 := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{{
+			ParentID:         genesisTxn.SiacoinOutputID(0),
+			UnlockConditions: uc1,
+		}},
+		SiacoinOutputs: func() (result []types.SiacoinOutput) {
+			val := genesisTxn.SiacoinOutputs[0].Value
+			// send 1000 small outputs to addr2
+			for range 1000 {
+				amount := types.NewCurrency64(1)
+				result = append(result, types.SiacoinOutput{
+					Address: addr2,
+					Value:   amount,
+				})
+				val = val.Sub(amount)
+			}
+			// send change to addr3
+			result = append(result, types.SiacoinOutput{
+				Address: addr3,
+				Value:   val,
+			})
+			return
+		}(),
+	}
+	testutil.SignTransaction(n.tipState(), pk1, &txn1)
+
+	n.mineTransactions(b, txn1)
+
+	benchmarks := []struct {
+		name   string
+		addr   types.Address
+		offset uint64
+	}{
+		{"addr1 (no unspent outputs)", addr1, 0},
+		{"addr2 (outputs 0-99)", addr2, 0},
+		{"addr2 (outputs 100-199)", addr2, 100},
+		{"addr3 (1 output)", addr3, 0},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for range b.N {
+				_, err := n.db.UnspentSiacoinOutputs(bm.addr, bm.offset, 100)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }

--- a/persist/sqlite/consensus_refactored_test.go
+++ b/persist/sqlite/consensus_refactored_test.go
@@ -2642,24 +2642,17 @@ func BenchmarkTransactions(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	benchmarks := []struct {
-		limit int
-	}{
-		{10},
-		{100},
-		{1000},
-	}
 	b.ResetTimer()
-	for _, bm := range benchmarks {
-		b.Run(strconv.Itoa(bm.limit)+" transactions", func(b *testing.B) {
-			offset := frand.Intn(len(ids) - bm.limit)
-			txnIDs := ids[offset : offset+bm.limit]
+	for _, limit := range []int{10, 100, 1000} {
+		b.Run(strconv.Itoa(limit)+" transactions", func(b *testing.B) {
+			offset := frand.Intn(len(ids) - limit)
+			txnIDs := ids[offset : offset+limit]
 			for range b.N {
 				txns, err := n.db.Transactions(txnIDs)
 				if err != nil {
 					b.Fatal(err)
 				}
-				testutil.Equal(b, "len(txns)", bm.limit, len(txns))
+				testutil.Equal(b, "len(txns)", limit, len(txns))
 			}
 		})
 	}
@@ -2682,7 +2675,7 @@ func BenchmarkSiacoinOutputs(b *testing.B) {
 		val := encode(types.NewCurrency64(1))
 
 		var addr types.Address
-		for i := range 1_000_000 {
+		for i := range 5_000_000 {
 			if i%100_000 == 0 {
 				b.Log("Inserted siacoin element:", i)
 			}
@@ -2727,45 +2720,31 @@ func BenchmarkSiacoinOutputs(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	unspentBenchmarks := []struct {
-		limit uint64
-	}{
-		{10},
-		{100},
-		{1000},
-	}
 	b.ResetTimer()
-	for _, bm := range unspentBenchmarks {
-		b.Run(strconv.FormatUint(bm.limit, 10)+" unspent outputs", func(b *testing.B) {
-			offset := frand.Uint64n(1000 - bm.limit + 1)
+	for _, limit := range []uint64{10, 100, 1000} {
+		b.Run(strconv.FormatUint(limit, 10)+" unspent outputs", func(b *testing.B) {
+			offset := frand.Uint64n(1000 - limit + 1)
 			for range b.N {
-				sces, err := n.db.UnspentSiacoinOutputs(addr1, offset, bm.limit)
+				sces, err := n.db.UnspentSiacoinOutputs(addr1, offset, limit)
 				if err != nil {
 					b.Fatal(err)
 				}
-				testutil.Equal(b, "len(sces)", bm.limit, uint64(len(sces)))
+				testutil.Equal(b, "len(sces)", limit, uint64(len(sces)))
 			}
 		})
 	}
 
-	benchmarks := []struct {
-		limit int
-	}{
-		{10},
-		{100},
-		{1000},
-	}
 	b.ResetTimer()
-	for _, bm := range benchmarks {
-		b.Run(strconv.Itoa(bm.limit)+" siacoin elements", func(b *testing.B) {
-			offset := frand.Intn(len(ids) - bm.limit)
-			scIDs := ids[offset : offset+bm.limit]
+	for _, limit := range []int{10, 100, 1000} {
+		b.Run(strconv.Itoa(limit)+" siacoin elements", func(b *testing.B) {
+			offset := frand.Intn(len(ids) - limit)
+			scIDs := ids[offset : offset+limit]
 			for range b.N {
 				sces, err := n.db.SiacoinElements(scIDs)
 				if err != nil {
 					b.Fatal(err)
 				}
-				testutil.Equal(b, "len(sces)", bm.limit, len(sces))
+				testutil.Equal(b, "len(sces)", limit, len(sces))
 			}
 		})
 	}

--- a/persist/sqlite/merkle.go
+++ b/persist/sqlite/merkle.go
@@ -1,44 +1,67 @@
 package sqlite
 
 import (
+	"fmt"
 	"math/bits"
 
 	"go.sia.tech/core/types"
 )
 
-func merkleProof(tx *txn, leafIndex uint64) ([]types.Hash256, error) {
+func fillElementProofs(tx *txn, indices []uint64) (proofs [][]types.Hash256, _ error) {
+	if len(indices) == 0 {
+		return nil, nil
+	}
+
 	var numLeaves uint64
-	if err := tx.QueryRow("SELECT num_leaves FROM network_metrics ORDER BY height DESC LIMIT 1").Scan(decode(&numLeaves)); err != nil {
-		return nil, err
+	if err := tx.QueryRow(`SELECT num_leaves FROM network_metrics ORDER BY height DESC LIMIT 1`).Scan(decode(&numLeaves)); err != nil {
+		return nil, fmt.Errorf("failed to query state tree leaves: %w", err)
 	}
 
-	pos := leafIndex
-	stmt, err := tx.Prepare("SELECT value FROM state_tree WHERE row = ? AND column = ?")
+	stmt, err := tx.Prepare(`SELECT value FROM state_tree WHERE row=? AND column=?`)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to prepare statement: %w", err)
 	}
+	defer stmt.Close()
 
-	proof := make([]types.Hash256, bits.Len64(leafIndex^numLeaves)-1)
-	for i := range proof {
-		subtreeSize := uint64(1 << i)
-		if leafIndex&(1<<i) == 0 {
-			pos += subtreeSize
-		} else {
-			pos -= subtreeSize
+	data := make(map[uint64]map[uint64]types.Hash256)
+	for _, leafIndex := range indices {
+		proof := make([]types.Hash256, bits.Len64(leafIndex^numLeaves)-1)
+		for j := range proof {
+			row, col := uint64(j), (leafIndex>>j)^1
+
+			// check if the hash is already in the cache
+			if h, ok := data[row][col]; ok {
+				proof[j] = h
+				continue
+			}
+
+			// query the hash from the database
+			if err := stmt.QueryRow(row, col).Scan(decode(&proof[j])); err != nil {
+				return nil, fmt.Errorf("failed to query state element (%d,%d): %w", row, col, err)
+			}
+
+			// cache the hash
+			if _, ok := data[row]; !ok {
+				data[row] = make(map[uint64]types.Hash256)
+			}
+			data[row][col] = proof[j]
 		}
-		// read hash (i, pos/subtreeSize)
-		if err := stmt.QueryRow(i, pos/subtreeSize).Scan(decode(&proof[i])); err != nil {
-			return nil, err
-		}
+		proofs = append(proofs, proof)
 	}
-	return proof, nil
+	return
 }
 
 // MerkleProof implements explorer.Store.
 func (s *Store) MerkleProof(leafIndex uint64) (proof []types.Hash256, err error) {
 	err = s.transaction(func(tx *txn) error {
-		proof, err = merkleProof(tx, leafIndex)
-		return err
+		proofs, err := fillElementProofs(tx, []uint64{leafIndex})
+		if err != nil {
+			return err
+		} else if len(proofs) != 1 {
+			return fmt.Errorf("expected 1 merkle proof, got %d", len(proofs))
+		}
+		proof = proofs[0]
+		return nil
 	})
 	return
 }

--- a/persist/sqlite/v2consensus_refactored_test.go
+++ b/persist/sqlite/v2consensus_refactored_test.go
@@ -1,4 +1,4 @@
-package sqlite_test
+package sqlite
 
 import (
 	"errors"

--- a/persist/sqlite/v2consensus_refactored_test.go
+++ b/persist/sqlite/v2consensus_refactored_test.go
@@ -15,7 +15,7 @@ import (
 	"go.sia.tech/explored/internal/testutil"
 )
 
-func getSCE(t *testing.T, db explorer.Store, scid types.SiacoinOutputID) types.SiacoinElement {
+func getSCE(t testing.TB, db explorer.Store, scid types.SiacoinOutputID) types.SiacoinElement {
 	t.Helper()
 
 	sces, err := db.SiacoinElements([]types.SiacoinOutputID{scid})
@@ -27,7 +27,7 @@ func getSCE(t *testing.T, db explorer.Store, scid types.SiacoinOutputID) types.S
 	return sces[0].SiacoinElement
 }
 
-func getSFE(t *testing.T, db explorer.Store, sfid types.SiafundOutputID) types.SiafundElement {
+func getSFE(t testing.TB, db explorer.Store, sfid types.SiafundOutputID) types.SiafundElement {
 	t.Helper()
 
 	sfes, err := db.SiafundElements([]types.SiafundOutputID{sfid})
@@ -39,7 +39,7 @@ func getSFE(t *testing.T, db explorer.Store, sfid types.SiafundOutputID) types.S
 	return sfes[0].SiafundElement
 }
 
-func getFCE(t *testing.T, db explorer.Store, fcid types.FileContractID) types.V2FileContractElement {
+func getFCE(t testing.TB, db explorer.Store, fcid types.FileContractID) types.V2FileContractElement {
 	t.Helper()
 
 	fces, err := db.V2Contracts([]types.FileContractID{fcid})
@@ -51,7 +51,7 @@ func getFCE(t *testing.T, db explorer.Store, fcid types.FileContractID) types.V2
 	return fces[0].V2FileContractElement
 }
 
-func getCIE(t *testing.T, db explorer.Store, bid types.BlockID) types.ChainIndexElement {
+func getCIE(t testing.TB, db explorer.Store, bid types.BlockID) types.ChainIndexElement {
 	t.Helper()
 
 	b, err := db.Block(bid)
@@ -73,14 +73,14 @@ func getCIE(t *testing.T, db explorer.Store, bid types.BlockID) types.ChainIndex
 	}
 }
 
-func (n *testChain) mineV2Transactions(t *testing.T, txns ...types.V2Transaction) {
+func (n *testChain) mineV2Transactions(t testing.TB, txns ...types.V2Transaction) {
 	t.Helper()
 
 	b := testutil.MineV2Block(n.tipState(), txns, types.VoidAddress)
 	n.applyBlock(t, b)
 }
 
-func (n *testChain) assertV2Transactions(t *testing.T, expected ...types.V2Transaction) {
+func (n *testChain) assertV2Transactions(t testing.TB, expected ...types.V2Transaction) {
 	t.Helper()
 
 	for _, txn := range expected {
@@ -94,7 +94,7 @@ func (n *testChain) assertV2Transactions(t *testing.T, expected ...types.V2Trans
 	}
 }
 
-func (n *testChain) assertV2ChainIndices(t *testing.T, txnID types.TransactionID, expected ...types.ChainIndex) {
+func (n *testChain) assertV2ChainIndices(t testing.TB, txnID types.TransactionID, expected ...types.ChainIndex) {
 	t.Helper()
 
 	indices, err := n.db.V2TransactionChainIndices(txnID, 0, math.MaxInt64)
@@ -109,7 +109,7 @@ func (n *testChain) assertV2ChainIndices(t *testing.T, txnID types.TransactionID
 	}
 }
 
-func checkV2Contract(t *testing.T, expected explorer.V2FileContract, got explorer.V2FileContract) {
+func checkV2Contract(t testing.TB, expected explorer.V2FileContract, got explorer.V2FileContract) {
 	t.Helper()
 
 	testutil.Equal(t, "V2FileContract", expected.V2FileContractElement.V2FileContract, got.V2FileContractElement.V2FileContract)
@@ -125,7 +125,7 @@ func checkV2Contract(t *testing.T, expected explorer.V2FileContract, got explore
 
 // assertV2FCE asserts the contract element in the db has the right state and
 // block/transaction indices
-func (n *testChain) assertV2FCE(t *testing.T, fcID types.FileContractID, expected explorer.V2FileContract) {
+func (n *testChain) assertV2FCE(t testing.TB, fcID types.FileContractID, expected explorer.V2FileContract) {
 	t.Helper()
 
 	fces, err := n.db.V2Contracts([]types.FileContractID{fcID})
@@ -139,7 +139,7 @@ func (n *testChain) assertV2FCE(t *testing.T, fcID types.FileContractID, expecte
 
 // assertNoV2FCE asserts the contract element in the db has the right state and
 // block/transaction indices
-func (n *testChain) assertNoV2FCE(t *testing.T, fcIDs ...types.FileContractID) {
+func (n *testChain) assertNoV2FCE(t testing.TB, fcIDs ...types.FileContractID) {
 	t.Helper()
 
 	fces, err := n.db.V2Contracts(fcIDs)
@@ -152,7 +152,7 @@ func (n *testChain) assertNoV2FCE(t *testing.T, fcIDs ...types.FileContractID) {
 // assertV2TransactionContracts asserts that the enhanced FileContracts
 // in a v2 transaction retrieved from the explorer match the expected
 // contracts.
-func (n *testChain) assertV2TransactionContracts(t *testing.T, txnID types.TransactionID, revisions bool, expected ...explorer.V2FileContract) {
+func (n *testChain) assertV2TransactionContracts(t testing.TB, txnID types.TransactionID, revisions bool, expected ...explorer.V2FileContract) {
 	t.Helper()
 
 	txns, err := n.db.V2Transactions([]types.TransactionID{txnID})
@@ -178,7 +178,7 @@ func (n *testChain) assertV2TransactionContracts(t *testing.T, txnID types.Trans
 // assertV2TransactionResolutions asserts that the enhanced
 // FileContractResolutions in a v2 transaction retrieved from the explorer
 // match the expected resolutions.
-func (n *testChain) assertV2TransactionResolutions(t *testing.T, txnID types.TransactionID, expected ...explorer.V2FileContractResolution) {
+func (n *testChain) assertV2TransactionResolutions(t testing.TB, txnID types.TransactionID, expected ...explorer.V2FileContractResolution) {
 	t.Helper()
 
 	txns, err := n.db.V2Transactions([]types.TransactionID{txnID})
@@ -209,7 +209,7 @@ func (n *testChain) assertV2TransactionResolutions(t *testing.T, txnID types.Tra
 	}
 }
 
-func (n *testChain) assertV2ContractRevisions(t *testing.T, fcID types.FileContractID, expected ...explorer.V2FileContract) {
+func (n *testChain) assertV2ContractRevisions(t testing.TB, fcID types.FileContractID, expected ...explorer.V2FileContract) {
 	t.Helper()
 
 	fces, err := n.db.V2ContractRevisions(fcID)
@@ -228,7 +228,7 @@ func (n *testChain) assertV2ContractRevisions(t *testing.T, fcID types.FileContr
 	}
 }
 
-func (n *testChain) getV2FCE(t *testing.T, fcID types.FileContractID) explorer.V2FileContract {
+func (n *testChain) getV2FCE(t testing.TB, fcID types.FileContractID) explorer.V2FileContract {
 	t.Helper()
 
 	fces, err := n.db.V2Contracts([]types.FileContractID{fcID})
@@ -241,7 +241,7 @@ func (n *testChain) getV2FCE(t *testing.T, fcID types.FileContractID) explorer.V
 	return fces[0]
 }
 
-func (n *testChain) getV2Txn(t *testing.T, txnID types.TransactionID) explorer.V2Transaction {
+func (n *testChain) getV2Txn(t testing.TB, txnID types.TransactionID) explorer.V2Transaction {
 	t.Helper()
 
 	txns, err := n.db.V2Transactions([]types.TransactionID{txnID})


### PR DESCRIPTION
Latest benchmarks:
```
BenchmarkTransactions/10_transactions
BenchmarkTransactions/10_transactions-4                      940           1219615 ns/op
BenchmarkTransactions/100_transactions
BenchmarkTransactions/100_transactions-4                     142           8281356 ns/op
BenchmarkTransactions/1000_transactions
BenchmarkTransactions/1000_transactions-4                     14          78907892 ns/op

BenchmarkSiacoinOutputs/10_unspent_outputs
BenchmarkSiacoinOutputs/10_unspent_outputs-4                6830            230802 ns/op
BenchmarkSiacoinOutputs/100_unspent_outputs
BenchmarkSiacoinOutputs/100_unspent_outputs-4               1513            862293 ns/op
BenchmarkSiacoinOutputs/1000_unspent_outputs
BenchmarkSiacoinOutputs/1000_unspent_outputs-4               164           7006526 ns/op

BenchmarkSiacoinOutputs/10_siacoin_elements
BenchmarkSiacoinOutputs/10_siacoin_elements-4               4574            272862 ns/op
BenchmarkSiacoinOutputs/100_siacoin_elements
BenchmarkSiacoinOutputs/100_siacoin_elements-4               968           1285014 ns/op
BenchmarkSiacoinOutputs/1000_siacoin_elements
BenchmarkSiacoinOutputs/1000_siacoin_elements-4               96          12238006 ns/op
```
https://github.com/SiaFoundation/explored/issues/201