### PR TITLE
Fix case where some payout events were not added

### DIFF
--- a/explorer/events.go
+++ b/explorer/events.go
@@ -465,7 +465,7 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) (events []
 	for _, diff := range cu.FileContractElementDiffs() {
 		fce, resolved, valid := diff.FileContractElement, diff.Resolved, diff.Valid
 		if !resolved {
-			return
+			continue
 		}
 
 		fce.StateElement.MerkleProof = nil
@@ -518,7 +518,7 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate) (events []
 	for _, diff := range cu.V2FileContractElementDiffs() {
 		fce, res := diff.V2FileContractElement, diff.Resolution
 		if res == nil {
-			return
+			continue
 		}
 
 		fce.StateElement.MerkleProof = nil

--- a/persist/sqlite/init.go
+++ b/persist/sqlite/init.go
@@ -21,7 +21,7 @@ func initializeSettings(tx *txn, target int64) error {
 	return err
 }
 
-func (s *Store) initNewDatabase(tx *txn, target int64) error {
+func initNewDatabase(tx *txn, target int64) error {
 	if _, err := tx.Exec(initDatabase); err != nil {
 		return fmt.Errorf("failed to initialize database: %w", err)
 	} else if err := initializeSettings(tx, target); err != nil {
@@ -90,7 +90,7 @@ func (s *Store) init() error {
 	switch {
 	case version == 0:
 		return s.transaction(func(tx *txn) error {
-			return s.initNewDatabase(tx, target)
+			return initNewDatabase(tx, target)
 		})
 	case version < target:
 		return s.upgradeDatabase(version, target)


### PR DESCRIPTION
`AppliedEvents` would return early if it encountered a file contract element diff that was not a resolution instead of continuing the loop, which would result in miner payout events and foundation subsidy events not being in included in the list of events if a block contained contract formations or revisions.  This fixes that and adds a related test.