### PR TITLE
Fix issue where forming v1 file contracts with nonzero revision numbers would fail 

### DIFF
--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -182,8 +182,8 @@ func addFileContracts(tx *txn, id int64, txn types.Transaction, fcDBIds map[expl
 	}
 	defer stmt.Close()
 
-	for i := range txn.FileContracts {
-		dbID, ok := fcDBIds[explorer.DBFileContract{ID: txn.FileContractID(i), RevisionNumber: 0}]
+	for i, fc := range txn.FileContracts {
+		dbID, ok := fcDBIds[explorer.DBFileContract{ID: txn.FileContractID(i), RevisionNumber: fc.RevisionNumber}]
 		if !ok {
 			return errors.New("addFileContracts: fcDbID not in map")
 		}


### PR DESCRIPTION
In `addFileContracts` we assume that the revision number of a v1 file contract being formed is 0 when looking up its database ID in the map.  There is no consensus rule which requires that to be the case.  Given that this hasn't happened before, no migration is required (we'd know because the node would get stuck indexing at a certain height).