### PR TITLE
Clean up inserts

### DIFF
--- a/persist/sqlite/revert.go
+++ b/persist/sqlite/revert.go
@@ -263,7 +263,7 @@ func (ut *updateTx) RevertIndex(state explorer.UpdateState) error {
 		return fmt.Errorf("RevertIndex: failed to update balances: %w", err)
 	} else if err := updateFileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.FileContractElements); err != nil {
 		return fmt.Errorf("RevertIndex: failed to update file contract state: %w", err)
-	} else if _, err := updateV2FileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.V2FileContractElements); err != nil {
+	} else if err := updateV2FileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.V2FileContractElements); err != nil {
 		return fmt.Errorf("RevertIndex: failed to add v2 file contracts: %w", err)
 	} else if err := updateFileContractIndices(ut.tx, true, state.Metrics.Index, state.FileContractElements); err != nil {
 		return fmt.Errorf("RevertIndex: failed to update file contract element indices: %w", err)

--- a/persist/sqlite/revert.go
+++ b/persist/sqlite/revert.go
@@ -245,14 +245,14 @@ func deleteBlock(tx *txn, bid types.BlockID) error {
 func (ut *updateTx) RevertIndex(state explorer.UpdateState) error {
 	if err := updateMaturedBalances(ut.tx, true, state.Metrics.Index.Height); err != nil {
 		return fmt.Errorf("RevertIndex: failed to update matured balances: %w", err)
-	} else if _, err := addSiacoinElements(
+	} else if err := addSiacoinElements(
 		ut.tx,
 		state.Metrics.Index,
 		state.SpentSiacoinElements,
 		append(state.NewSiacoinElements, state.EphemeralSiacoinElements...),
 	); err != nil {
 		return fmt.Errorf("RevertIndex: failed to update siacoin output state: %w", err)
-	} else if _, err := addSiafundElements(
+	} else if err := addSiafundElements(
 		ut.tx,
 		state.Metrics.Index,
 		state.SpentSiafundElements,
@@ -261,7 +261,7 @@ func (ut *updateTx) RevertIndex(state explorer.UpdateState) error {
 		return fmt.Errorf("RevertIndex: failed to update siafund output state: %w", err)
 	} else if err := updateBalances(ut.tx, state.Metrics.Index.Height, state.SpentSiacoinElements, state.NewSiacoinElements, state.SpentSiafundElements, state.NewSiafundElements); err != nil {
 		return fmt.Errorf("RevertIndex: failed to update balances: %w", err)
-	} else if _, err := updateFileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.FileContractElements); err != nil {
+	} else if err := updateFileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.FileContractElements); err != nil {
 		return fmt.Errorf("RevertIndex: failed to update file contract state: %w", err)
 	} else if _, err := updateV2FileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.V2FileContractElements); err != nil {
 		return fmt.Errorf("RevertIndex: failed to add v2 file contracts: %w", err)

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -2,7 +2,6 @@ package sqlite
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"go.sia.tech/core/types"
@@ -70,14 +69,14 @@ func addV2Transactions(tx *txn, bid types.BlockID, txns []types.V2Transaction) (
 	return txnDBIds, nil
 }
 
-func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, b types.Block, fces []explorer.V2FileContractUpdate) (map[explorer.DBFileContract]int64, error) {
+func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, b types.Block, fces []explorer.V2FileContractUpdate) error {
 	stmt, err := tx.Prepare(`INSERT INTO v2_file_contract_elements(contract_id, block_id, transaction_id, leaf_index, capacity, filesize, file_merkle_root, proof_height, expiration_height, renter_output_address, renter_output_value, host_output_address, host_output_value, missed_host_value, total_collateral, renter_public_key, host_public_key, revision_number, renter_signature, host_signature)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (contract_id, revision_number)
         DO UPDATE SET leaf_index = ?
         RETURNING id;`)
 	if err != nil {
-		return nil, fmt.Errorf("updateV2FileContractElements: failed to prepare main statement: %w", err)
+		return fmt.Errorf("updateV2FileContractElements: failed to prepare main statement: %w", err)
 	}
 	defer stmt.Close()
 
@@ -86,14 +85,14 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
     ON CONFLICT (contract_id)
     DO UPDATE SET contract_element_id = ?, confirmation_height = COALESCE(?, confirmation_height), confirmation_block_id = COALESCE(?, confirmation_block_id), confirmation_transaction_id = COALESCE(?, confirmation_transaction_id)`)
 	if err != nil {
-		return nil, fmt.Errorf("updateV2FileContractElements: failed to prepare last_contract_revision statement: %w", err)
+		return fmt.Errorf("updateV2FileContractElements: failed to prepare last_contract_revision statement: %w", err)
 	}
 	defer revisionStmt.Close()
 
 	// so we can get the ids of revision parents to add to the DB
 	parentStmt, err := tx.Prepare(`SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?`)
 	if err != nil {
-		return nil, fmt.Errorf("updateV2FileContractElements: failed to prepare parent statement: %w", err)
+		return fmt.Errorf("updateV2FileContractElements: failed to prepare parent statement: %w", err)
 	}
 	defer parentStmt.Close()
 
@@ -123,7 +122,7 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 		}
 	}
 
-	fcDBIds := make(map[explorer.DBFileContract]int64)
+	seen := make(map[explorer.DBFileContract]struct{})
 	addFC := func(fcID types.FileContractID, leafIndex uint64, fc types.V2FileContract, confirmationTransactionID *types.TransactionID, lastRevision bool) error {
 		var dbID int64
 		dbFC := explorer.DBFileContract{ID: fcID, RevisionNumber: fc.RevisionNumber}
@@ -147,7 +146,7 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 			}
 		}
 
-		fcDBIds[dbFC] = dbID
+		seen[dbFC] = struct{}{}
 		return nil
 	}
 
@@ -187,12 +186,12 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 			update.ConfirmationTransactionID,
 			true,
 		); err != nil {
-			return nil, fmt.Errorf("updateV2FileContractElements: %w", err)
+			return fmt.Errorf("updateV2FileContractElements: %w", err)
 		}
 	}
 
 	if revert {
-		return fcDBIds, nil
+		return nil
 	}
 
 	for _, txn := range b.V2Transactions() {
@@ -201,12 +200,12 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 		for j, fc := range txn.FileContracts {
 			fcID := txn.V2FileContractID(txn.ID(), j)
 			dbFC := explorer.DBFileContract{ID: fcID, RevisionNumber: fc.RevisionNumber}
-			if _, exists := fcDBIds[dbFC]; exists {
+			if _, exists := seen[dbFC]; exists {
 				continue
 			}
 
 			if err := addFC(fcID, 0, fc, nil, false); err != nil {
-				return nil, fmt.Errorf("updateV2FileContractElements: %w", err)
+				return fmt.Errorf("updateV2FileContractElements: %w", err)
 			}
 		}
 		// add in any revisions that are not the latest, i.e. contracts that
@@ -215,12 +214,12 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 			fc := fcr.Revision
 			fcID := types.FileContractID(fcr.Parent.ID)
 			dbFC := explorer.DBFileContract{ID: fcID, RevisionNumber: fc.RevisionNumber}
-			if _, exists := fcDBIds[dbFC]; exists {
+			if _, exists := seen[dbFC]; exists {
 				continue
 			}
 
 			if err := addFC(fcID, 0, fc, nil, false); err != nil {
-				return nil, fmt.Errorf("updateV2FileContractElements: %w", err)
+				return fmt.Errorf("updateV2FileContractElements: %w", err)
 			}
 		}
 		// Add the new renewal contracts
@@ -234,41 +233,19 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 					fc := v.NewContract
 					fcID := types.FileContractID(fcr.Parent.ID).V2RenewalID()
 					dbFC := explorer.DBFileContract{ID: fcID, RevisionNumber: fc.RevisionNumber}
-					if _, exists := fcDBIds[dbFC]; exists {
+					if _, exists := seen[dbFC]; exists {
 						continue
 					}
 
 					if err := addFC(fcID, 0, fc, nil, false); err != nil {
-						return nil, fmt.Errorf("updateV2FileContractElements: failed to add new contract: %w", err)
+						return fmt.Errorf("updateV2FileContractElements: failed to add new contract: %w", err)
 					}
 				}
 			}
 		}
-		// don't add anything, just set parent db IDs in fcDBIds map
-		for _, fcr := range txn.FileContractRevisions {
-			fcID := types.FileContractID(fcr.Parent.ID)
-			parentDBFC := explorer.DBFileContract{ID: fcID, RevisionNumber: fcr.Parent.V2FileContract.RevisionNumber}
-
-			var dbID int64
-			if err := parentStmt.QueryRow(encode(fcID), encode(parentDBFC.RevisionNumber)).Scan(&dbID); err != nil {
-				return nil, fmt.Errorf("updateV2FileContractElements: failed to get parent contract ID: %w", err)
-			}
-			fcDBIds[parentDBFC] = dbID
-		}
-		// don't add anything, just set parent db IDs in fcDBIds map
-		for _, fcr := range txn.FileContractResolutions {
-			fcID := types.FileContractID(fcr.Parent.ID)
-			parentDBFC := explorer.DBFileContract{ID: fcID, RevisionNumber: fcr.Parent.V2FileContract.RevisionNumber}
-
-			var dbID int64
-			if err := parentStmt.QueryRow(encode(fcID), encode(parentDBFC.RevisionNumber)).Scan(&dbID); err != nil {
-				return nil, fmt.Errorf("updateV2FileContractElements: failed to get parent contract ID: %w", err)
-			}
-			fcDBIds[parentDBFC] = dbID
-		}
 	}
 
-	return fcDBIds, nil
+	return nil
 }
 
 func updateV2FileContractIndices(tx *txn, revert bool, index types.ChainIndex, fces []explorer.V2FileContractUpdate) error {
@@ -379,108 +356,68 @@ func addV2SiafundOutputs(tx *txn, txnID int64, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2FileContracts(tx *txn, txnID int64, txn types.V2Transaction, dbIDs map[explorer.DBFileContract]int64) error {
-	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, ?)`)
+func addV2FileContracts(tx *txn, txnID int64, txn types.V2Transaction) error {
+	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContracts: failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, fc := range txn.FileContracts {
-		dbID, ok := dbIDs[explorer.DBFileContract{
-			ID:             txn.V2FileContractID(txn.ID(), i),
-			RevisionNumber: fc.RevisionNumber,
-		}]
-		if !ok {
-			return errors.New("addV2FileContracts: dbID not in map")
-		}
-
-		if _, err := stmt.Exec(txnID, i, dbID); err != nil {
+		if _, err := stmt.Exec(txnID, i, encode(txn.V2FileContractID(txn.ID(), i)), encode(fc.RevisionNumber)); err != nil {
 			return fmt.Errorf("addV2FileContracts: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2FileContractRevisions(tx *txn, txnID int64, txn types.V2Transaction, dbIDs map[explorer.DBFileContract]int64) error {
-	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_revisions(transaction_id, transaction_order, parent_contract_id, revision_contract_id) VALUES (?, ?, ?, ?)`)
+func addV2FileContractRevisions(tx *txn, txnID int64, txn types.V2Transaction) error {
+	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_revisions(transaction_id, transaction_order, parent_contract_id, revision_contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContractRevisions: failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, fcr := range txn.FileContractRevisions {
-		parentDBID, ok := dbIDs[explorer.DBFileContract{
-			ID:             types.FileContractID(fcr.Parent.ID),
-			RevisionNumber: fcr.Parent.V2FileContract.RevisionNumber,
-		}]
-		if !ok {
-			return errors.New("addV2FileContractRevisions: parent dbID not in map")
-		}
-
-		dbID, ok := dbIDs[explorer.DBFileContract{
-			ID:             types.FileContractID(fcr.Parent.ID),
-			RevisionNumber: fcr.Revision.RevisionNumber,
-		}]
-		if !ok {
-			return errors.New("addV2FileContractRevisions: dbID not in map")
-		}
-
-		if _, err := stmt.Exec(txnID, i, parentDBID, dbID); err != nil {
+		if _, err := stmt.Exec(txnID, i, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Revision.RevisionNumber)); err != nil {
 			return fmt.Errorf("addV2FileContractRevisions: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2FileContractResolutions(tx *txn, txnID int64, txn types.V2Transaction, dbIDs map[explorer.DBFileContract]int64) error {
-	renewalStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, parent_contract_id, resolution_type, renewal_new_contract_id, renewal_final_renter_output_address, renewal_final_renter_output_value, renewal_final_host_output_address, renewal_final_host_output_value, renewal_renter_rollover, renewal_host_rollover, renewal_renter_signature, renewal_host_signature) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+func addV2FileContractResolutions(tx *txn, txnID int64, txn types.V2Transaction) error {
+	renewalStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, parent_contract_id, resolution_type, renewal_new_contract_id, renewal_final_renter_output_address, renewal_final_renter_output_value, renewal_final_host_output_address, renewal_final_host_output_value, renewal_renter_rollover, renewal_host_rollover, renewal_renter_signature, renewal_host_signature) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContractResolutions: failed to prepare renewal statement: %w", err)
 	}
 	defer renewalStmt.Close()
 
-	storageProofStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, parent_contract_id, resolution_type, storage_proof_proof_index, storage_proof_leaf, storage_proof_proof) VALUES (?, ?, ?, ?, ?, ?, ?)`)
+	storageProofStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, parent_contract_id, resolution_type, storage_proof_proof_index, storage_proof_leaf, storage_proof_proof) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContractResolutions: failed to prepare storage proof statement: %w", err)
 	}
 	defer storageProofStmt.Close()
 
-	expirationStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, parent_contract_id, resolution_type) VALUES (?, ?, ?, ?)`)
+	expirationStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, parent_contract_id, resolution_type) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), ?)`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContractResolutions: failed to prepare expiration statement: %w", err)
 	}
 	defer expirationStmt.Close()
 
 	for i, fcr := range txn.FileContractResolutions {
-		parentDBID, ok := dbIDs[explorer.DBFileContract{
-			ID:             types.FileContractID(fcr.Parent.ID),
-			RevisionNumber: fcr.Parent.V2FileContract.RevisionNumber,
-		}]
-		if !ok {
-			return errors.New("addV2FileContractResolutions: parent dbID not in map")
-		}
-
 		resolutionType := explorer.V2ResolutionType(fcr.Resolution)
 		switch v := fcr.Resolution.(type) {
 		case *types.V2FileContractRenewal:
-			newDBID, ok := dbIDs[explorer.DBFileContract{
-				ID:             types.FileContractID(fcr.Parent.ID).V2RenewalID(),
-				RevisionNumber: v.NewContract.RevisionNumber,
-			}]
-			if !ok {
-				return errors.New("addV2FileContractResolutions: renewal dbID not in map")
-			}
-
-			if _, err := renewalStmt.Exec(txnID, i, parentDBID, resolutionType, newDBID, encode(v.FinalRenterOutput.Address), encode(v.FinalRenterOutput.Value), encode(v.FinalHostOutput.Address), encode(v.FinalHostOutput.Value), encode(v.RenterRollover), encode(v.HostRollover), encode(v.RenterSignature), encode(v.HostSignature)); err != nil {
+			if _, err := renewalStmt.Exec(txnID, i, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), resolutionType, encode(types.FileContractID(fcr.Parent.ID).V2RenewalID()), encode(v.NewContract.RevisionNumber), encode(v.FinalRenterOutput.Address), encode(v.FinalRenterOutput.Value), encode(v.FinalHostOutput.Address), encode(v.FinalHostOutput.Value), encode(v.RenterRollover), encode(v.HostRollover), encode(v.RenterSignature), encode(v.HostSignature)); err != nil {
 				return fmt.Errorf("addV2FileContractResolutions: failed to execute renewal statement: %w", err)
 			}
 		case *types.V2StorageProof:
-			if _, err := storageProofStmt.Exec(txnID, i, parentDBID, resolutionType, encode(v.ProofIndex), v.Leaf[:], encode(v.Proof)); err != nil {
+			if _, err := storageProofStmt.Exec(txnID, i, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), resolutionType, encode(v.ProofIndex), v.Leaf[:], encode(v.Proof)); err != nil {
 				return fmt.Errorf("addV2FileContractResolutions: failed to execute storage proof statement: %w", err)
 			}
 		case *types.V2FileContractExpiration:
-			if _, err := expirationStmt.Exec(txnID, i, parentDBID, resolutionType); err != nil {
+			if _, err := expirationStmt.Exec(txnID, i, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), resolutionType); err != nil {
 				return fmt.Errorf("addV2FileContractResolutions: failed to execute expiration statement: %w", err)
 			}
 		}
@@ -503,7 +440,7 @@ func addV2Attestations(tx *txn, txnID int64, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2TransactionFields(tx *txn, txns []types.V2Transaction, v2FcDBIds map[explorer.DBFileContract]int64, v2TxnDBIds map[types.TransactionID]txnDBId) error {
+func addV2TransactionFields(tx *txn, txns []types.V2Transaction, v2TxnDBIds map[types.TransactionID]txnDBId) error {
 	for _, txn := range txns {
 		txnID := txn.ID()
 		dbID, ok := v2TxnDBIds[txnID]
@@ -529,11 +466,11 @@ func addV2TransactionFields(tx *txn, txns []types.V2Transaction, v2FcDBIds map[e
 			return fmt.Errorf("failed to add siafund inputs: %w", err)
 		} else if err := addV2SiafundOutputs(tx, dbID.id, txn); err != nil {
 			return fmt.Errorf("failed to add siafund outputs: %w", err)
-		} else if err := addV2FileContracts(tx, dbID.id, txn, v2FcDBIds); err != nil {
+		} else if err := addV2FileContracts(tx, dbID.id, txn); err != nil {
 			return fmt.Errorf("failed to add file contracts: %w", err)
-		} else if err := addV2FileContractRevisions(tx, dbID.id, txn, v2FcDBIds); err != nil {
+		} else if err := addV2FileContractRevisions(tx, dbID.id, txn); err != nil {
 			return fmt.Errorf("failed to add file contract revisions: %w", err)
-		} else if err := addV2FileContractResolutions(tx, dbID.id, txn, v2FcDBIds); err != nil {
+		} else if err := addV2FileContractResolutions(tx, dbID.id, txn); err != nil {
 			return fmt.Errorf("failed to add file contract resolutions: %w", err)
 		}
 	}


### PR DESCRIPTION
Remove usage of maps that map v1/v2 file contract element IDs, siacoin element IDs, and siafund elements IDs to their integer IDs in the database and instead retrieve those IDs using subqueries.

`master`
```
BenchmarkApplyRevert/apply-4                 246       4828469 ns/op
BenchmarkApplyRevert/revert-4                 33      33822119 ns/op
```

`christopher/clean-up-inserts`:
```
BenchmarkApplyRevert/apply-4                 247       5129194 ns/op
BenchmarkApplyRevert/revert-4                 34      33314049 ns/op
```

Given that indexing is already pretty slow I'm not sure whether we are OK with a slowdown though this one is relatively small.

https://github.com/SiaFoundation/explored/issues/208
