### PR TITLE
Remove transaction ID maps

### DIFF
--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -44,8 +44,8 @@ func addMinerPayouts(tx *txn, bid types.BlockID, scos []types.SiacoinOutput) err
 	return nil
 }
 
-func addMinerFees(tx *txn, dbID int64, txn types.Transaction) error {
-	if len(txn.MinerFees) == 0 {
+func addMinerFees(tx *txn, dbID int64, minerFees []types.Currency) error {
+	if len(minerFees) == 0 {
 		return nil
 	}
 
@@ -55,7 +55,7 @@ func addMinerFees(tx *txn, dbID int64, txn types.Transaction) error {
 	}
 	defer stmt.Close()
 
-	for i, fee := range txn.MinerFees {
+	for i, fee := range minerFees {
 		if _, err := stmt.Exec(dbID, i, encode(fee)); err != nil {
 			return fmt.Errorf("addMinerFees: failed to execute statement: %w", err)
 		}
@@ -63,8 +63,8 @@ func addMinerFees(tx *txn, dbID int64, txn types.Transaction) error {
 	return nil
 }
 
-func addArbitraryData(tx *txn, dbID int64, txn types.Transaction) error {
-	if len(txn.ArbitraryData) == 0 {
+func addArbitraryData(tx *txn, dbID int64, arbitraryData [][]byte) error {
+	if len(arbitraryData) == 0 {
 		return nil
 	}
 
@@ -74,16 +74,16 @@ func addArbitraryData(tx *txn, dbID int64, txn types.Transaction) error {
 	}
 	defer stmt.Close()
 
-	for i, arbitraryData := range txn.ArbitraryData {
-		if _, err := stmt.Exec(dbID, i, arbitraryData); err != nil {
+	for i, arb := range arbitraryData {
+		if _, err := stmt.Exec(dbID, i, arb); err != nil {
 			return fmt.Errorf("addArbitraryData: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addSignatures(tx *txn, dbID int64, txn types.Transaction) error {
-	if len(txn.Signatures) == 0 {
+func addSignatures(tx *txn, dbID int64, signatures []types.TransactionSignature) error {
+	if len(signatures) == 0 {
 		return nil
 	}
 
@@ -93,7 +93,7 @@ func addSignatures(tx *txn, dbID int64, txn types.Transaction) error {
 	}
 	defer stmt.Close()
 
-	for i, sig := range txn.Signatures {
+	for i, sig := range signatures {
 		if _, err := stmt.Exec(dbID, i, encode(sig.ParentID), sig.PublicKeyIndex, encode(sig.Timelock), encode(sig.CoveredFields), sig.Signature); err != nil {
 			return fmt.Errorf("addSignatures: failed to execute statement: %w", err)
 		}
@@ -101,8 +101,8 @@ func addSignatures(tx *txn, dbID int64, txn types.Transaction) error {
 	return nil
 }
 
-func addSiacoinInputs(tx *txn, dbID int64, txn types.Transaction) error {
-	if len(txn.SiacoinInputs) == 0 {
+func addSiacoinInputs(tx *txn, dbID int64, siacoinInputs []types.SiacoinInput) error {
+	if len(siacoinInputs) == 0 {
 		return nil
 	}
 
@@ -112,7 +112,7 @@ func addSiacoinInputs(tx *txn, dbID int64, txn types.Transaction) error {
 	}
 	defer stmt.Close()
 
-	for i, sci := range txn.SiacoinInputs {
+	for i, sci := range siacoinInputs {
 		if _, err := stmt.Exec(dbID, i, encode(sci.UnlockConditions), encode(sci.ParentID)); err != nil {
 			return fmt.Errorf("addSiacoinInputs: failed to execute statement: %w", err)
 		}
@@ -139,8 +139,8 @@ func addSiacoinOutputs(tx *txn, dbID int64, txn types.Transaction) error {
 	return nil
 }
 
-func addSiafundInputs(tx *txn, dbID int64, txn types.Transaction) error {
-	if len(txn.SiafundInputs) == 0 {
+func addSiafundInputs(tx *txn, dbID int64, siafundInputs []types.SiafundInput) error {
+	if len(siafundInputs) == 0 {
 		return nil
 	}
 
@@ -150,7 +150,7 @@ func addSiafundInputs(tx *txn, dbID int64, txn types.Transaction) error {
 	}
 	defer stmt.Close()
 
-	for i, sfi := range txn.SiafundInputs {
+	for i, sfi := range siafundInputs {
 		if _, err := stmt.Exec(dbID, i, encode(sfi.UnlockConditions), encode(sfi.ClaimAddress), encode(sfi.ParentID)); err != nil {
 			return fmt.Errorf("addSiafundInputs: failed to execute statement: %w", err)
 		}
@@ -197,8 +197,8 @@ func addFileContracts(tx *txn, dbID int64, txn types.Transaction) error {
 	return nil
 }
 
-func addFileContractRevisions(tx *txn, dbID int64, txn types.Transaction) error {
-	if len(txn.FileContractRevisions) == 0 {
+func addFileContractRevisions(tx *txn, dbID int64, fileContractRevisions []types.FileContractRevision) error {
+	if len(fileContractRevisions) == 0 {
 		return nil
 	}
 
@@ -208,8 +208,7 @@ func addFileContractRevisions(tx *txn, dbID int64, txn types.Transaction) error 
 	}
 	defer stmt.Close()
 
-	for i := range txn.FileContractRevisions {
-		fcr := &txn.FileContractRevisions[i]
+	for i, fcr := range fileContractRevisions {
 		if _, err := stmt.Exec(dbID, i, encode(fcr.ParentID), encode(fcr.UnlockConditions), encode(fcr.ParentID), encode(fcr.FileContract.RevisionNumber)); err != nil {
 			return fmt.Errorf("addFileContractRevisions: failed to execute statement: %w", err)
 		}
@@ -218,8 +217,8 @@ func addFileContractRevisions(tx *txn, dbID int64, txn types.Transaction) error 
 	return nil
 }
 
-func addStorageProofs(tx *txn, dbID int64, txn types.Transaction) error {
-	if len(txn.StorageProofs) == 0 {
+func addStorageProofs(tx *txn, dbID int64, storageProofs []types.StorageProof) error {
+	if len(storageProofs) == 0 {
 		return nil
 	}
 
@@ -229,7 +228,7 @@ func addStorageProofs(tx *txn, dbID int64, txn types.Transaction) error {
 	}
 	defer stmt.Close()
 
-	for i, proof := range txn.StorageProofs {
+	for i, proof := range storageProofs {
 		if _, err := stmt.Exec(dbID, i, encode(proof.ParentID), proof.Leaf[:], encode(proof.Proof)); err != nil {
 			return fmt.Errorf("addStorageProofs: failed to execute statement: %w", err)
 		}
@@ -325,25 +324,25 @@ func addTransactionFields(tx *txn, txns []types.Transaction, txnExist map[types.
 			return fmt.Errorf("failed to scan for transaction ID: %w", err)
 		}
 
-		if err := addMinerFees(tx, dbID, txn); err != nil {
+		if err := addMinerFees(tx, dbID, txn.MinerFees); err != nil {
 			return fmt.Errorf("failed to add miner fees: %w", err)
-		} else if err := addArbitraryData(tx, dbID, txn); err != nil {
+		} else if err := addArbitraryData(tx, dbID, txn.ArbitraryData); err != nil {
 			return fmt.Errorf("failed to add arbitrary data: %w", err)
-		} else if err := addSignatures(tx, dbID, txn); err != nil {
+		} else if err := addSignatures(tx, dbID, txn.Signatures); err != nil {
 			return fmt.Errorf("failed to add signatures: %w", err)
-		} else if err := addSiacoinInputs(tx, dbID, txn); err != nil {
+		} else if err := addSiacoinInputs(tx, dbID, txn.SiacoinInputs); err != nil {
 			return fmt.Errorf("failed to add siacoin inputs: %w", err)
 		} else if err := addSiacoinOutputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin outputs: %w", err)
-		} else if err := addSiafundInputs(tx, dbID, txn); err != nil {
+		} else if err := addSiafundInputs(tx, dbID, txn.SiafundInputs); err != nil {
 			return fmt.Errorf("failed to add siafund inputs: %w", err)
 		} else if err := addSiafundOutputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siafund outputs: %w", err)
 		} else if err := addFileContracts(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add file contract: %w", err)
-		} else if err := addFileContractRevisions(tx, dbID, txn); err != nil {
+		} else if err := addFileContractRevisions(tx, dbID, txn.FileContractRevisions); err != nil {
 			return fmt.Errorf("failed to add file contract revisions: %w", err)
-		} else if err := addStorageProofs(tx, dbID, txn); err != nil {
+		} else if err := addStorageProofs(tx, dbID, txn.StorageProofs); err != nil {
 			return fmt.Errorf("failed to add storage proofs: %w", err)
 		}
 	}

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -56,7 +56,7 @@ func addMinerFees(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addMinerFees: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_miner_fees(transaction_id, transaction_order, fee) VALUES (?, ?, ?)`)
@@ -80,7 +80,7 @@ func addArbitraryData(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addArbitraryData: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_arbitrary_data(transaction_id, transaction_order, data) VALUES (?, ?, ?)`)
@@ -104,18 +104,18 @@ func addSignatures(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addSignatures: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_signatures(transaction_id, transaction_order, parent_id, public_key_index, timelock, covered_fields, signature) VALUES (?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
-		return fmt.Errorf("addMinerFees: failed to prepare statement: %w", err)
+		return fmt.Errorf("addSignatures: failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, sig := range txn.Signatures {
 		if _, err := stmt.Exec(dbID, i, encode(sig.ParentID), sig.PublicKeyIndex, encode(sig.Timelock), encode(sig.CoveredFields), sig.Signature); err != nil {
-			return fmt.Errorf("addMinerFees: failed to execute statement: %w", err)
+			return fmt.Errorf("addSignatures: failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -128,7 +128,7 @@ func addSiacoinInputs(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addSiacoinInputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siacoin_inputs(transaction_id, transaction_order, unlock_conditions, parent_id) VALUES (?, ?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
@@ -152,7 +152,7 @@ func addSiacoinOutputs(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addSiacoinOutputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siacoin_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
@@ -176,7 +176,7 @@ func addSiafundInputs(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addSiafundInputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siafund_inputs(transaction_id, transaction_order, unlock_conditions, claim_address, parent_id) VALUES (?, ?, ?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
@@ -201,7 +201,7 @@ func addSiafundOutputs(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addSiafundOutputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siafund_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
@@ -225,7 +225,7 @@ func addFileContracts(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addFileContracts: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, (SELECT id FROM file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
@@ -249,7 +249,7 @@ func addFileContractRevisions(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addFileContractRevisions: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_file_contract_revisions(transaction_id, transaction_order, parent_id, unlock_conditions, contract_id) VALUES (?, ?, ?, ?, (SELECT id FROM file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
@@ -275,7 +275,7 @@ func addStorageProofs(tx *txn, txn types.Transaction) error {
 
 	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addStorageProofs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_storage_proofs(transaction_id, transaction_order, parent_id, leaf, proof) VALUES (?, ?, ?, ?, ?)`)

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -49,12 +49,12 @@ func getTransactionID(tx *txn, txnID types.TransactionID) (result int64, err err
 	return
 }
 
-func addMinerFees(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addMinerFees(tx *txn, txn types.Transaction) error {
 	if len(txn.MinerFees) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -73,12 +73,12 @@ func addMinerFees(tx *txn, txnID types.TransactionID, txn types.Transaction) err
 	return nil
 }
 
-func addArbitraryData(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addArbitraryData(tx *txn, txn types.Transaction) error {
 	if len(txn.ArbitraryData) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -97,12 +97,12 @@ func addArbitraryData(tx *txn, txnID types.TransactionID, txn types.Transaction)
 	return nil
 }
 
-func addSignatures(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addSignatures(tx *txn, txn types.Transaction) error {
 	if len(txn.Signatures) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -121,12 +121,12 @@ func addSignatures(tx *txn, txnID types.TransactionID, txn types.Transaction) er
 	return nil
 }
 
-func addSiacoinInputs(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addSiacoinInputs(tx *txn, txn types.Transaction) error {
 	if len(txn.SiacoinInputs) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -145,12 +145,12 @@ func addSiacoinInputs(tx *txn, txnID types.TransactionID, txn types.Transaction)
 	return nil
 }
 
-func addSiacoinOutputs(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addSiacoinOutputs(tx *txn, txn types.Transaction) error {
 	if len(txn.SiacoinOutputs) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -169,12 +169,12 @@ func addSiacoinOutputs(tx *txn, txnID types.TransactionID, txn types.Transaction
 	return nil
 }
 
-func addSiafundInputs(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addSiafundInputs(tx *txn, txn types.Transaction) error {
 	if len(txn.SiafundInputs) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -194,12 +194,12 @@ func addSiafundInputs(tx *txn, txnID types.TransactionID, txn types.Transaction)
 	return nil
 }
 
-func addSiafundOutputs(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addSiafundOutputs(tx *txn, txn types.Transaction) error {
 	if len(txn.SiafundOutputs) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -218,12 +218,12 @@ func addSiafundOutputs(tx *txn, txnID types.TransactionID, txn types.Transaction
 	return nil
 }
 
-func addFileContracts(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addFileContracts(tx *txn, txn types.Transaction) error {
 	if len(txn.FileContracts) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -242,12 +242,12 @@ func addFileContracts(tx *txn, txnID types.TransactionID, txn types.Transaction)
 	return nil
 }
 
-func addFileContractRevisions(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addFileContractRevisions(tx *txn, txn types.Transaction) error {
 	if len(txn.FileContractRevisions) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -268,12 +268,12 @@ func addFileContractRevisions(tx *txn, txnID types.TransactionID, txn types.Tran
 	return nil
 }
 
-func addStorageProofs(tx *txn, txnID types.TransactionID, txn types.Transaction) error {
+func addStorageProofs(tx *txn, txn types.Transaction) error {
 	if len(txn.StorageProofs) == 0 {
 		return nil
 	}
 
-	dbID, err := getTransactionID(tx, txnID)
+	dbID, err := getTransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -370,25 +370,25 @@ func addTransactionFields(tx *txn, txns []types.Transaction, txnDBIds map[types.
 		// multiple of the same transaction in a block
 		txnDBIds[txnID] = txnDBId{id: dbID.id, exist: true}
 
-		if err := addMinerFees(tx, txnID, txn); err != nil {
+		if err := addMinerFees(tx, txn); err != nil {
 			return fmt.Errorf("failed to add miner fees: %w", err)
-		} else if err := addArbitraryData(tx, txnID, txn); err != nil {
+		} else if err := addArbitraryData(tx, txn); err != nil {
 			return fmt.Errorf("failed to add arbitrary data: %w", err)
-		} else if err := addSignatures(tx, txnID, txn); err != nil {
+		} else if err := addSignatures(tx, txn); err != nil {
 			return fmt.Errorf("failed to add signatures: %w", err)
-		} else if err := addSiacoinInputs(tx, txnID, txn); err != nil {
+		} else if err := addSiacoinInputs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin inputs: %w", err)
-		} else if err := addSiacoinOutputs(tx, txnID, txn); err != nil {
+		} else if err := addSiacoinOutputs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin outputs: %w", err)
-		} else if err := addSiafundInputs(tx, txnID, txn); err != nil {
+		} else if err := addSiafundInputs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add siafund inputs: %w", err)
-		} else if err := addSiafundOutputs(tx, txnID, txn); err != nil {
+		} else if err := addSiafundOutputs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add siafund outputs: %w", err)
-		} else if err := addFileContracts(tx, txnID, txn); err != nil {
+		} else if err := addFileContracts(tx, txn); err != nil {
 			return fmt.Errorf("failed to add file contract: %w", err)
-		} else if err := addFileContractRevisions(tx, txnID, txn); err != nil {
+		} else if err := addFileContractRevisions(tx, txn); err != nil {
 			return fmt.Errorf("failed to add file contract revisions: %w", err)
-		} else if err := addStorageProofs(tx, txnID, txn); err != nil {
+		} else if err := addStorageProofs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add storage proofs: %w", err)
 		}
 	}

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -44,19 +44,9 @@ func addMinerPayouts(tx *txn, bid types.BlockID, scos []types.SiacoinOutput) err
 	return nil
 }
 
-func getTransactionID(tx *txn, txnID types.TransactionID) (result int64, err error) {
-	err = tx.QueryRow(`SELECT id FROM transactions WHERE transaction_id = ?`, encode(txnID)).Scan(&result)
-	return
-}
-
-func addMinerFees(tx *txn, txn types.Transaction) error {
+func addMinerFees(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.MinerFees) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addMinerFees: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_miner_fees(transaction_id, transaction_order, fee) VALUES (?, ?, ?)`)
@@ -73,14 +63,9 @@ func addMinerFees(tx *txn, txn types.Transaction) error {
 	return nil
 }
 
-func addArbitraryData(tx *txn, txn types.Transaction) error {
+func addArbitraryData(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.ArbitraryData) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addArbitraryData: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_arbitrary_data(transaction_id, transaction_order, data) VALUES (?, ?, ?)`)
@@ -97,14 +82,9 @@ func addArbitraryData(tx *txn, txn types.Transaction) error {
 	return nil
 }
 
-func addSignatures(tx *txn, txn types.Transaction) error {
+func addSignatures(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.Signatures) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addSignatures: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_signatures(transaction_id, transaction_order, parent_id, public_key_index, timelock, covered_fields, signature) VALUES (?, ?, ?, ?, ?, ?, ?)`)
@@ -121,14 +101,9 @@ func addSignatures(tx *txn, txn types.Transaction) error {
 	return nil
 }
 
-func addSiacoinInputs(tx *txn, txn types.Transaction) error {
+func addSiacoinInputs(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.SiacoinInputs) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addSiacoinInputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siacoin_inputs(transaction_id, transaction_order, unlock_conditions, parent_id) VALUES (?, ?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
@@ -145,14 +120,9 @@ func addSiacoinInputs(tx *txn, txn types.Transaction) error {
 	return nil
 }
 
-func addSiacoinOutputs(tx *txn, txn types.Transaction) error {
+func addSiacoinOutputs(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.SiacoinOutputs) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addSiacoinOutputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siacoin_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
@@ -169,14 +139,9 @@ func addSiacoinOutputs(tx *txn, txn types.Transaction) error {
 	return nil
 }
 
-func addSiafundInputs(tx *txn, txn types.Transaction) error {
+func addSiafundInputs(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.SiafundInputs) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addSiafundInputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siafund_inputs(transaction_id, transaction_order, unlock_conditions, claim_address, parent_id) VALUES (?, ?, ?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
@@ -194,14 +159,9 @@ func addSiafundInputs(tx *txn, txn types.Transaction) error {
 	return nil
 }
 
-func addSiafundOutputs(tx *txn, txn types.Transaction) error {
+func addSiafundOutputs(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.SiafundOutputs) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addSiafundOutputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siafund_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
@@ -218,14 +178,9 @@ func addSiafundOutputs(tx *txn, txn types.Transaction) error {
 	return nil
 }
 
-func addFileContracts(tx *txn, txn types.Transaction) error {
+func addFileContracts(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.FileContracts) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addFileContracts: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, (SELECT id FROM file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
@@ -242,14 +197,9 @@ func addFileContracts(tx *txn, txn types.Transaction) error {
 	return nil
 }
 
-func addFileContractRevisions(tx *txn, txn types.Transaction) error {
+func addFileContractRevisions(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.FileContractRevisions) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addFileContractRevisions: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_file_contract_revisions(transaction_id, transaction_order, parent_id, unlock_conditions, contract_id) VALUES (?, ?, ?, ?, (SELECT id FROM file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
@@ -268,14 +218,9 @@ func addFileContractRevisions(tx *txn, txn types.Transaction) error {
 	return nil
 }
 
-func addStorageProofs(tx *txn, txn types.Transaction) error {
+func addStorageProofs(tx *txn, dbID int64, txn types.Transaction) error {
 	if len(txn.StorageProofs) == 0 {
 		return nil
-	}
-
-	dbID, err := getTransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addStorageProofs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_storage_proofs(transaction_id, transaction_order, parent_id, leaf, proof) VALUES (?, ?, ?, ?, ?)`)
@@ -355,6 +300,11 @@ func addTransactions(tx *txn, bid types.BlockID, txns []types.Transaction) (map[
 }
 
 func addTransactionFields(tx *txn, txns []types.Transaction, txnExist map[types.TransactionID]bool) error {
+	stmt, err := tx.Prepare(`SELECT id FROM transactions WHERE transaction_id = ?`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare transaction ID statement: %w", err)
+	}
+
 	for _, txn := range txns {
 		txnID := txn.ID()
 		exist, ok := txnExist[txnID]
@@ -370,25 +320,30 @@ func addTransactionFields(tx *txn, txns []types.Transaction, txnExist map[types.
 		// multiple of the same transaction in a block
 		txnExist[txnID] = true
 
-		if err := addMinerFees(tx, txn); err != nil {
+		var dbID int64
+		if err := stmt.QueryRow(encode(txnID)).Scan(&dbID); err != nil {
+			return fmt.Errorf("failed to scan for transaction ID: %w", err)
+		}
+
+		if err := addMinerFees(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add miner fees: %w", err)
-		} else if err := addArbitraryData(tx, txn); err != nil {
+		} else if err := addArbitraryData(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add arbitrary data: %w", err)
-		} else if err := addSignatures(tx, txn); err != nil {
+		} else if err := addSignatures(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add signatures: %w", err)
-		} else if err := addSiacoinInputs(tx, txn); err != nil {
+		} else if err := addSiacoinInputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin inputs: %w", err)
-		} else if err := addSiacoinOutputs(tx, txn); err != nil {
+		} else if err := addSiacoinOutputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin outputs: %w", err)
-		} else if err := addSiafundInputs(tx, txn); err != nil {
+		} else if err := addSiafundInputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siafund inputs: %w", err)
-		} else if err := addSiafundOutputs(tx, txn); err != nil {
+		} else if err := addSiafundOutputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siafund outputs: %w", err)
-		} else if err := addFileContracts(tx, txn); err != nil {
+		} else if err := addFileContracts(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add file contract: %w", err)
-		} else if err := addFileContractRevisions(tx, txn); err != nil {
+		} else if err := addFileContractRevisions(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add file contract revisions: %w", err)
-		} else if err := addStorageProofs(tx, txn); err != nil {
+		} else if err := addStorageProofs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add storage proofs: %w", err)
 		}
 	}

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -294,7 +294,17 @@ func updateV2FileContractIndices(tx *txn, revert bool, index types.ChainIndex, f
 	return nil
 }
 
-func addV2SiacoinInputs(tx *txn, txnID int64, txn types.V2Transaction) error {
+func getV2TransactionID(tx *txn, txnID types.TransactionID) (result int64, err error) {
+	err = tx.QueryRow(`SELECT id FROM v2_transactions WHERE transaction_id = ?`, encode(txnID)).Scan(&result)
+	return
+}
+
+func addV2SiacoinInputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	dbID, err := getV2TransactionID(tx, txnID)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction ID: %w", err)
+	}
+
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siacoin_inputs(transaction_id, transaction_order, satisfied_policy, parent_id) VALUES (?, ?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2SiacoinInputs: failed to prepare statement: %w", err)
@@ -302,14 +312,19 @@ func addV2SiacoinInputs(tx *txn, txnID int64, txn types.V2Transaction) error {
 	defer stmt.Close()
 
 	for i, sci := range txn.SiacoinInputs {
-		if _, err := stmt.Exec(txnID, i, encode(sci.SatisfiedPolicy), encode(types.SiacoinOutputID(sci.Parent.ID))); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(sci.SatisfiedPolicy), encode(types.SiacoinOutputID(sci.Parent.ID))); err != nil {
 			return fmt.Errorf("addV2SiacoinInputs: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2SiacoinOutputs(tx *txn, txnID int64, txn types.V2Transaction) error {
+func addV2SiacoinOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	dbID, err := getV2TransactionID(tx, txnID)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction ID: %w", err)
+	}
+
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siacoin_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2SiacoinOutputs: failed to prepare statement: %w", err)
@@ -318,14 +333,19 @@ func addV2SiacoinOutputs(tx *txn, txnID int64, txn types.V2Transaction) error {
 
 	id := txn.ID()
 	for i := range txn.SiacoinOutputs {
-		if _, err := stmt.Exec(txnID, i, encode(txn.SiacoinOutputID(id, i))); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(txn.SiacoinOutputID(id, i))); err != nil {
 			return fmt.Errorf("addV2SiacoinOutputs: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2SiafundInputs(tx *txn, txnID int64, txn types.V2Transaction) error {
+func addV2SiafundInputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	dbID, err := getV2TransactionID(tx, txnID)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction ID: %w", err)
+	}
+
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siafund_inputs(transaction_id, transaction_order, claim_address, satisfied_policy, parent_id) VALUES (?, ?, ?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2SiafundInputs: failed to prepare statement: %w", err)
@@ -333,14 +353,19 @@ func addV2SiafundInputs(tx *txn, txnID int64, txn types.V2Transaction) error {
 	defer stmt.Close()
 
 	for i, sfi := range txn.SiafundInputs {
-		if _, err := stmt.Exec(txnID, i, encode(sfi.ClaimAddress), encode(sfi.SatisfiedPolicy), encode(types.SiafundOutputID(sfi.Parent.ID))); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(sfi.ClaimAddress), encode(sfi.SatisfiedPolicy), encode(types.SiafundOutputID(sfi.Parent.ID))); err != nil {
 			return fmt.Errorf("addV2SiafundInputs: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2SiafundOutputs(tx *txn, txnID int64, txn types.V2Transaction) error {
+func addV2SiafundOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	dbID, err := getV2TransactionID(tx, txnID)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction ID: %w", err)
+	}
+
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siafund_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2SiafundOutputs: failed to prepare statement: %w", err)
@@ -349,14 +374,19 @@ func addV2SiafundOutputs(tx *txn, txnID int64, txn types.V2Transaction) error {
 
 	id := txn.ID()
 	for i := range txn.SiafundOutputs {
-		if _, err := stmt.Exec(txnID, i, encode(txn.SiafundOutputID(id, i))); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(txn.SiafundOutputID(id, i))); err != nil {
 			return fmt.Errorf("addV2SiafundOutputs: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2FileContracts(tx *txn, txnID int64, txn types.V2Transaction) error {
+func addV2FileContracts(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	dbID, err := getV2TransactionID(tx, txnID)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction ID: %w", err)
+	}
+
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContracts: failed to prepare statement: %w", err)
@@ -364,14 +394,19 @@ func addV2FileContracts(tx *txn, txnID int64, txn types.V2Transaction) error {
 	defer stmt.Close()
 
 	for i, fc := range txn.FileContracts {
-		if _, err := stmt.Exec(txnID, i, encode(txn.V2FileContractID(txn.ID(), i)), encode(fc.RevisionNumber)); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(txn.V2FileContractID(txn.ID(), i)), encode(fc.RevisionNumber)); err != nil {
 			return fmt.Errorf("addV2FileContracts: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2FileContractRevisions(tx *txn, txnID int64, txn types.V2Transaction) error {
+func addV2FileContractRevisions(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	dbID, err := getV2TransactionID(tx, txnID)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction ID: %w", err)
+	}
+
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_revisions(transaction_id, transaction_order, parent_contract_id, revision_contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContractRevisions: failed to prepare statement: %w", err)
@@ -379,14 +414,19 @@ func addV2FileContractRevisions(tx *txn, txnID int64, txn types.V2Transaction) e
 	defer stmt.Close()
 
 	for i, fcr := range txn.FileContractRevisions {
-		if _, err := stmt.Exec(txnID, i, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Revision.RevisionNumber)); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Revision.RevisionNumber)); err != nil {
 			return fmt.Errorf("addV2FileContractRevisions: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2FileContractResolutions(tx *txn, txnID int64, txn types.V2Transaction) error {
+func addV2FileContractResolutions(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	dbID, err := getV2TransactionID(tx, txnID)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction ID: %w", err)
+	}
+
 	renewalStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, resolution_type, renewal_final_renter_output_address, renewal_final_renter_output_value, renewal_final_host_output_address, renewal_final_host_output_value, renewal_renter_rollover, renewal_host_rollover, renewal_renter_signature, renewal_host_signature, parent_contract_id, renewal_new_contract_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContractResolutions: failed to prepare renewal statement: %w", err)
@@ -409,15 +449,15 @@ func addV2FileContractResolutions(tx *txn, txnID int64, txn types.V2Transaction)
 		resolutionType := explorer.V2ResolutionType(fcr.Resolution)
 		switch v := fcr.Resolution.(type) {
 		case *types.V2FileContractRenewal:
-			if _, err := renewalStmt.Exec(txnID, i, resolutionType, encode(v.FinalRenterOutput.Address), encode(v.FinalRenterOutput.Value), encode(v.FinalHostOutput.Address), encode(v.FinalHostOutput.Value), encode(v.RenterRollover), encode(v.HostRollover), encode(v.RenterSignature), encode(v.HostSignature), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), encode(types.FileContractID(fcr.Parent.ID).V2RenewalID()), encode(v.NewContract.RevisionNumber)); err != nil {
+			if _, err := renewalStmt.Exec(dbID, i, resolutionType, encode(v.FinalRenterOutput.Address), encode(v.FinalRenterOutput.Value), encode(v.FinalHostOutput.Address), encode(v.FinalHostOutput.Value), encode(v.RenterRollover), encode(v.HostRollover), encode(v.RenterSignature), encode(v.HostSignature), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), encode(types.FileContractID(fcr.Parent.ID).V2RenewalID()), encode(v.NewContract.RevisionNumber)); err != nil {
 				return fmt.Errorf("addV2FileContractResolutions: failed to execute renewal statement: %w", err)
 			}
 		case *types.V2StorageProof:
-			if _, err := storageProofStmt.Exec(txnID, i, resolutionType, encode(v.ProofIndex), v.Leaf[:], encode(v.Proof), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber)); err != nil {
+			if _, err := storageProofStmt.Exec(dbID, i, resolutionType, encode(v.ProofIndex), v.Leaf[:], encode(v.Proof), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber)); err != nil {
 				return fmt.Errorf("addV2FileContractResolutions: failed to execute storage proof statement: %w", err)
 			}
 		case *types.V2FileContractExpiration:
-			if _, err := expirationStmt.Exec(txnID, i, resolutionType, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber)); err != nil {
+			if _, err := expirationStmt.Exec(dbID, i, resolutionType, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber)); err != nil {
 				return fmt.Errorf("addV2FileContractResolutions: failed to execute expiration statement: %w", err)
 			}
 		}
@@ -425,7 +465,12 @@ func addV2FileContractResolutions(tx *txn, txnID int64, txn types.V2Transaction)
 	return nil
 }
 
-func addV2Attestations(tx *txn, txnID int64, txn types.V2Transaction) error {
+func addV2Attestations(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	dbID, err := getV2TransactionID(tx, txnID)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction ID: %w", err)
+	}
+
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_attestations(transaction_id, transaction_order, public_key, key, value, signature) VALUES (?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("addV2Attestations: failed to prepare statement: %w", err)
@@ -433,7 +478,7 @@ func addV2Attestations(tx *txn, txnID int64, txn types.V2Transaction) error {
 	defer stmt.Close()
 
 	for i, attestation := range txn.Attestations {
-		if _, err := stmt.Exec(txnID, i, encode(attestation.PublicKey), attestation.Key, attestation.Value, encode(attestation.Signature)); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(attestation.PublicKey), attestation.Key, attestation.Value, encode(attestation.Signature)); err != nil {
 			return fmt.Errorf("addV2Attestations: failed to execute statement: %w", err)
 		}
 	}
@@ -456,21 +501,21 @@ func addV2TransactionFields(tx *txn, txns []types.V2Transaction, v2TxnDBIds map[
 		// multiple of the same transaction in a block
 		v2TxnDBIds[txnID] = txnDBId{id: dbID.id, exist: true}
 
-		if err := addV2Attestations(tx, dbID.id, txn); err != nil {
+		if err := addV2Attestations(tx, txnID, txn); err != nil {
 			return fmt.Errorf("addV2TransactionFields: failed to add attestations: %w", err)
-		} else if err := addV2SiacoinInputs(tx, dbID.id, txn); err != nil {
+		} else if err := addV2SiacoinInputs(tx, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin inputs: %w", err)
-		} else if err := addV2SiacoinOutputs(tx, dbID.id, txn); err != nil {
+		} else if err := addV2SiacoinOutputs(tx, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin outputs: %w", err)
-		} else if err := addV2SiafundInputs(tx, dbID.id, txn); err != nil {
+		} else if err := addV2SiafundInputs(tx, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add siafund inputs: %w", err)
-		} else if err := addV2SiafundOutputs(tx, dbID.id, txn); err != nil {
+		} else if err := addV2SiafundOutputs(tx, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add siafund outputs: %w", err)
-		} else if err := addV2FileContracts(tx, dbID.id, txn); err != nil {
+		} else if err := addV2FileContracts(tx, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add file contracts: %w", err)
-		} else if err := addV2FileContractRevisions(tx, dbID.id, txn); err != nil {
+		} else if err := addV2FileContractRevisions(tx, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add file contract revisions: %w", err)
-		} else if err := addV2FileContractResolutions(tx, dbID.id, txn); err != nil {
+		} else if err := addV2FileContractResolutions(tx, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add file contract resolutions: %w", err)
 		}
 	}

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -294,19 +294,9 @@ func updateV2FileContractIndices(tx *txn, revert bool, index types.ChainIndex, f
 	return nil
 }
 
-func getV2TransactionID(tx *txn, txnID types.TransactionID) (result int64, err error) {
-	err = tx.QueryRow(`SELECT id FROM v2_transactions WHERE transaction_id = ?`, encode(txnID)).Scan(&result)
-	return
-}
-
-func addV2SiacoinInputs(tx *txn, txn types.V2Transaction) error {
+func addV2SiacoinInputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	if len(txn.SiacoinInputs) == 0 {
 		return nil
-	}
-
-	dbID, err := getV2TransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addV2SiacoinInputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siacoin_inputs(transaction_id, transaction_order, satisfied_policy, parent_id) VALUES (?, ?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
@@ -323,17 +313,12 @@ func addV2SiacoinInputs(tx *txn, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2SiacoinOutputs(tx *txn, txn types.V2Transaction) error {
+func addV2SiacoinOutputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	if len(txn.SiacoinOutputs) == 0 {
 		return nil
 	}
 
 	txnID := txn.ID()
-	dbID, err := getV2TransactionID(tx, txnID)
-	if err != nil {
-		return fmt.Errorf("addV2SiacoinOutputs: failed to get transaction ID: %w", err)
-	}
-
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siacoin_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2SiacoinOutputs: failed to prepare statement: %w", err)
@@ -348,14 +333,9 @@ func addV2SiacoinOutputs(tx *txn, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2SiafundInputs(tx *txn, txn types.V2Transaction) error {
+func addV2SiafundInputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	if len(txn.SiafundInputs) == 0 {
 		return nil
-	}
-
-	dbID, err := getV2TransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addV2SiafundInputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siafund_inputs(transaction_id, transaction_order, claim_address, satisfied_policy, parent_id) VALUES (?, ?, ?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
@@ -372,16 +352,12 @@ func addV2SiafundInputs(tx *txn, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2SiafundOutputs(tx *txn, txn types.V2Transaction) error {
+func addV2SiafundOutputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	if len(txn.SiafundOutputs) == 0 {
 		return nil
 	}
 
 	txnID := txn.ID()
-	dbID, err := getV2TransactionID(tx, txnID)
-	if err != nil {
-		return fmt.Errorf("addV2SiafundOutputs: failed to get transaction ID: %w", err)
-	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siafund_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
 	if err != nil {
@@ -397,17 +373,12 @@ func addV2SiafundOutputs(tx *txn, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2FileContracts(tx *txn, txn types.V2Transaction) error {
+func addV2FileContracts(tx *txn, dbID int64, txn types.V2Transaction) error {
 	if len(txn.FileContracts) == 0 {
 		return nil
 	}
 
 	txnID := txn.ID()
-	dbID, err := getV2TransactionID(tx, txnID)
-	if err != nil {
-		return fmt.Errorf("addV2FileContracts: failed to get transaction ID: %w", err)
-	}
-
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContracts: failed to prepare statement: %w", err)
@@ -422,14 +393,9 @@ func addV2FileContracts(tx *txn, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2FileContractRevisions(tx *txn, txn types.V2Transaction) error {
+func addV2FileContractRevisions(tx *txn, dbID int64, txn types.V2Transaction) error {
 	if len(txn.FileContractRevisions) == 0 {
 		return nil
-	}
-
-	dbID, err := getV2TransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addV2FileContractRevisions: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_revisions(transaction_id, transaction_order, parent_contract_id, revision_contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
@@ -446,14 +412,9 @@ func addV2FileContractRevisions(tx *txn, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2FileContractResolutions(tx *txn, txn types.V2Transaction) error {
+func addV2FileContractResolutions(tx *txn, dbID int64, txn types.V2Transaction) error {
 	if len(txn.FileContractResolutions) == 0 {
 		return nil
-	}
-
-	dbID, err := getV2TransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addV2FileContractResolutions: failed to get transaction ID: %w", err)
 	}
 
 	renewalStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, resolution_type, renewal_final_renter_output_address, renewal_final_renter_output_value, renewal_final_host_output_address, renewal_final_host_output_value, renewal_renter_rollover, renewal_host_rollover, renewal_renter_signature, renewal_host_signature, parent_contract_id, renewal_new_contract_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
@@ -494,14 +455,9 @@ func addV2FileContractResolutions(tx *txn, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2Attestations(tx *txn, txn types.V2Transaction) error {
+func addV2Attestations(tx *txn, dbID int64, txn types.V2Transaction) error {
 	if len(txn.Attestations) == 0 {
 		return nil
-	}
-
-	dbID, err := getV2TransactionID(tx, txn.ID())
-	if err != nil {
-		return fmt.Errorf("addV2Attestations: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_attestations(transaction_id, transaction_order, public_key, key, value, signature) VALUES (?, ?, ?, ?, ?, ?)`)
@@ -519,6 +475,11 @@ func addV2Attestations(tx *txn, txn types.V2Transaction) error {
 }
 
 func addV2TransactionFields(tx *txn, txns []types.V2Transaction, txnSeen map[types.TransactionID]bool) error {
+	stmt, err := tx.Prepare(`SELECT id FROM v2_transactions WHERE transaction_id = ?`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare transaction ID statement: %w", err)
+	}
+
 	for _, txn := range txns {
 		txnID := txn.ID()
 		exist, ok := txnSeen[txnID]
@@ -534,21 +495,26 @@ func addV2TransactionFields(tx *txn, txns []types.V2Transaction, txnSeen map[typ
 		// multiple of the same transaction in a block
 		txnSeen[txnID] = true
 
-		if err := addV2Attestations(tx, txn); err != nil {
+		var dbID int64
+		if err := stmt.QueryRow(encode(txnID)).Scan(&dbID); err != nil {
+			return fmt.Errorf("failed to scan for transaction ID: %w", err)
+		}
+
+		if err := addV2Attestations(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add attestations: %w", err)
-		} else if err := addV2SiacoinInputs(tx, txn); err != nil {
+		} else if err := addV2SiacoinInputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin inputs: %w", err)
-		} else if err := addV2SiacoinOutputs(tx, txn); err != nil {
+		} else if err := addV2SiacoinOutputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin outputs: %w", err)
-		} else if err := addV2SiafundInputs(tx, txn); err != nil {
+		} else if err := addV2SiafundInputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siafund inputs: %w", err)
-		} else if err := addV2SiafundOutputs(tx, txn); err != nil {
+		} else if err := addV2SiafundOutputs(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add siafund outputs: %w", err)
-		} else if err := addV2FileContracts(tx, txn); err != nil {
+		} else if err := addV2FileContracts(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add file contracts: %w", err)
-		} else if err := addV2FileContractRevisions(tx, txn); err != nil {
+		} else if err := addV2FileContractRevisions(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add file contract revisions: %w", err)
-		} else if err := addV2FileContractResolutions(tx, txn); err != nil {
+		} else if err := addV2FileContractResolutions(tx, dbID, txn); err != nil {
 			return fmt.Errorf("failed to add file contract resolutions: %w", err)
 		}
 	}

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -300,6 +300,10 @@ func getV2TransactionID(tx *txn, txnID types.TransactionID) (result int64, err e
 }
 
 func addV2SiacoinInputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	if len(txn.SiacoinInputs) == 0 {
+		return nil
+	}
+
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -320,6 +324,10 @@ func addV2SiacoinInputs(tx *txn, txnID types.TransactionID, txn types.V2Transact
 }
 
 func addV2SiacoinOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	if len(txn.SiacoinOutputs) == 0 {
+		return nil
+	}
+
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -341,6 +349,10 @@ func addV2SiacoinOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transac
 }
 
 func addV2SiafundInputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	if len(txn.SiafundInputs) == 0 {
+		return nil
+	}
+
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -361,6 +373,10 @@ func addV2SiafundInputs(tx *txn, txnID types.TransactionID, txn types.V2Transact
 }
 
 func addV2SiafundOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	if len(txn.SiafundOutputs) == 0 {
+		return nil
+	}
+
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -382,6 +398,10 @@ func addV2SiafundOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transac
 }
 
 func addV2FileContracts(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	if len(txn.FileContracts) == 0 {
+		return nil
+	}
+
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -402,6 +422,10 @@ func addV2FileContracts(tx *txn, txnID types.TransactionID, txn types.V2Transact
 }
 
 func addV2FileContractRevisions(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	if len(txn.FileContractRevisions) == 0 {
+		return nil
+	}
+
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -422,6 +446,10 @@ func addV2FileContractRevisions(tx *txn, txnID types.TransactionID, txn types.V2
 }
 
 func addV2FileContractResolutions(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	if len(txn.FileContractResolutions) == 0 {
+		return nil
+	}
+
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -466,6 +494,10 @@ func addV2FileContractResolutions(tx *txn, txnID types.TransactionID, txn types.
 }
 
 func addV2Attestations(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+	if len(txn.Attestations) == 0 {
+		return nil
+	}
+
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -306,7 +306,7 @@ func addV2SiacoinInputs(tx *txn, txn types.V2Transaction) error {
 
 	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addV2SiacoinInputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siacoin_inputs(transaction_id, transaction_order, satisfied_policy, parent_id) VALUES (?, ?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
@@ -331,7 +331,7 @@ func addV2SiacoinOutputs(tx *txn, txn types.V2Transaction) error {
 	txnID := txn.ID()
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addV2SiacoinOutputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siacoin_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
@@ -355,7 +355,7 @@ func addV2SiafundInputs(tx *txn, txn types.V2Transaction) error {
 
 	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addV2SiafundInputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siafund_inputs(transaction_id, transaction_order, claim_address, satisfied_policy, parent_id) VALUES (?, ?, ?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
@@ -380,7 +380,7 @@ func addV2SiafundOutputs(tx *txn, txn types.V2Transaction) error {
 	txnID := txn.ID()
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addV2SiafundOutputs: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siafund_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
@@ -405,7 +405,7 @@ func addV2FileContracts(tx *txn, txn types.V2Transaction) error {
 	txnID := txn.ID()
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addV2FileContracts: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
@@ -429,7 +429,7 @@ func addV2FileContractRevisions(tx *txn, txn types.V2Transaction) error {
 
 	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addV2FileContractRevisions: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_revisions(transaction_id, transaction_order, parent_contract_id, revision_contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
@@ -453,7 +453,7 @@ func addV2FileContractResolutions(tx *txn, txn types.V2Transaction) error {
 
 	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addV2FileContractResolutions: failed to get transaction ID: %w", err)
 	}
 
 	renewalStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, resolution_type, renewal_final_renter_output_address, renewal_final_renter_output_value, renewal_final_host_output_address, renewal_final_host_output_value, renewal_renter_rollover, renewal_host_rollover, renewal_renter_signature, renewal_host_signature, parent_contract_id, renewal_new_contract_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
@@ -501,7 +501,7 @@ func addV2Attestations(tx *txn, txn types.V2Transaction) error {
 
 	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get transaction ID: %w", err)
+		return fmt.Errorf("addV2Attestations: failed to get transaction ID: %w", err)
 	}
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_attestations(transaction_id, transaction_order, public_key, key, value, signature) VALUES (?, ?, ?, ?, ?, ?)`)
@@ -535,7 +535,7 @@ func addV2TransactionFields(tx *txn, txns []types.V2Transaction, txnSeen map[typ
 		txnSeen[txnID] = true
 
 		if err := addV2Attestations(tx, txn); err != nil {
-			return fmt.Errorf("addV2TransactionFields: failed to add attestations: %w", err)
+			return fmt.Errorf("failed to add attestations: %w", err)
 		} else if err := addV2SiacoinInputs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin inputs: %w", err)
 		} else if err := addV2SiacoinOutputs(tx, txn); err != nil {

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -294,8 +294,8 @@ func updateV2FileContractIndices(tx *txn, revert bool, index types.ChainIndex, f
 	return nil
 }
 
-func addV2SiacoinInputs(tx *txn, dbID int64, txn types.V2Transaction) error {
-	if len(txn.SiacoinInputs) == 0 {
+func addV2SiacoinInputs(tx *txn, dbID int64, siacoinInputs []types.V2SiacoinInput) error {
+	if len(siacoinInputs) == 0 {
 		return nil
 	}
 
@@ -305,7 +305,7 @@ func addV2SiacoinInputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	}
 	defer stmt.Close()
 
-	for i, sci := range txn.SiacoinInputs {
+	for i, sci := range siacoinInputs {
 		if _, err := stmt.Exec(dbID, i, encode(sci.SatisfiedPolicy), encode(types.SiacoinOutputID(sci.Parent.ID))); err != nil {
 			return fmt.Errorf("addV2SiacoinInputs: failed to execute statement: %w", err)
 		}
@@ -313,12 +313,11 @@ func addV2SiacoinInputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2SiacoinOutputs(tx *txn, dbID int64, txn types.V2Transaction) error {
+func addV2SiacoinOutputs(tx *txn, dbID int64, txnID types.TransactionID, txn types.V2Transaction) error {
 	if len(txn.SiacoinOutputs) == 0 {
 		return nil
 	}
 
-	txnID := txn.ID()
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siacoin_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2SiacoinOutputs: failed to prepare statement: %w", err)
@@ -333,8 +332,8 @@ func addV2SiacoinOutputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2SiafundInputs(tx *txn, dbID int64, txn types.V2Transaction) error {
-	if len(txn.SiafundInputs) == 0 {
+func addV2SiafundInputs(tx *txn, dbID int64, siafundInputs []types.V2SiafundInput) error {
+	if len(siafundInputs) == 0 {
 		return nil
 	}
 
@@ -344,7 +343,7 @@ func addV2SiafundInputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	}
 	defer stmt.Close()
 
-	for i, sfi := range txn.SiafundInputs {
+	for i, sfi := range siafundInputs {
 		if _, err := stmt.Exec(dbID, i, encode(sfi.ClaimAddress), encode(sfi.SatisfiedPolicy), encode(types.SiafundOutputID(sfi.Parent.ID))); err != nil {
 			return fmt.Errorf("addV2SiafundInputs: failed to execute statement: %w", err)
 		}
@@ -352,12 +351,10 @@ func addV2SiafundInputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2SiafundOutputs(tx *txn, dbID int64, txn types.V2Transaction) error {
+func addV2SiafundOutputs(tx *txn, dbID int64, txnID types.TransactionID, txn types.V2Transaction) error {
 	if len(txn.SiafundOutputs) == 0 {
 		return nil
 	}
-
-	txnID := txn.ID()
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siafund_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
 	if err != nil {
@@ -373,12 +370,11 @@ func addV2SiafundOutputs(tx *txn, dbID int64, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2FileContracts(tx *txn, dbID int64, txn types.V2Transaction) error {
+func addV2FileContracts(tx *txn, dbID int64, txnID types.TransactionID, txn types.V2Transaction) error {
 	if len(txn.FileContracts) == 0 {
 		return nil
 	}
 
-	txnID := txn.ID()
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
 		return fmt.Errorf("addV2FileContracts: failed to prepare statement: %w", err)
@@ -393,8 +389,8 @@ func addV2FileContracts(tx *txn, dbID int64, txn types.V2Transaction) error {
 	return nil
 }
 
-func addV2FileContractRevisions(tx *txn, dbID int64, txn types.V2Transaction) error {
-	if len(txn.FileContractRevisions) == 0 {
+func addV2FileContractRevisions(tx *txn, dbID int64, fileContractRevisions []types.V2FileContractRevision) error {
+	if len(fileContractRevisions) == 0 {
 		return nil
 	}
 
@@ -404,7 +400,7 @@ func addV2FileContractRevisions(tx *txn, dbID int64, txn types.V2Transaction) er
 	}
 	defer stmt.Close()
 
-	for i, fcr := range txn.FileContractRevisions {
+	for i, fcr := range fileContractRevisions {
 		if _, err := stmt.Exec(dbID, i, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Revision.RevisionNumber)); err != nil {
 			return fmt.Errorf("addV2FileContractRevisions: failed to execute statement: %w", err)
 		}
@@ -412,8 +408,8 @@ func addV2FileContractRevisions(tx *txn, dbID int64, txn types.V2Transaction) er
 	return nil
 }
 
-func addV2FileContractResolutions(tx *txn, dbID int64, txn types.V2Transaction) error {
-	if len(txn.FileContractResolutions) == 0 {
+func addV2FileContractResolutions(tx *txn, dbID int64, fileContractResolutions []types.V2FileContractResolution) error {
+	if len(fileContractResolutions) == 0 {
 		return nil
 	}
 
@@ -435,7 +431,7 @@ func addV2FileContractResolutions(tx *txn, dbID int64, txn types.V2Transaction) 
 	}
 	defer expirationStmt.Close()
 
-	for i, fcr := range txn.FileContractResolutions {
+	for i, fcr := range fileContractResolutions {
 		resolutionType := explorer.V2ResolutionType(fcr.Resolution)
 		switch v := fcr.Resolution.(type) {
 		case *types.V2FileContractRenewal:
@@ -455,8 +451,8 @@ func addV2FileContractResolutions(tx *txn, dbID int64, txn types.V2Transaction) 
 	return nil
 }
 
-func addV2Attestations(tx *txn, dbID int64, txn types.V2Transaction) error {
-	if len(txn.Attestations) == 0 {
+func addV2Attestations(tx *txn, dbID int64, attestations []types.Attestation) error {
+	if len(attestations) == 0 {
 		return nil
 	}
 
@@ -466,7 +462,7 @@ func addV2Attestations(tx *txn, dbID int64, txn types.V2Transaction) error {
 	}
 	defer stmt.Close()
 
-	for i, attestation := range txn.Attestations {
+	for i, attestation := range attestations {
 		if _, err := stmt.Exec(dbID, i, encode(attestation.PublicKey), attestation.Key, attestation.Value, encode(attestation.Signature)); err != nil {
 			return fmt.Errorf("addV2Attestations: failed to execute statement: %w", err)
 		}
@@ -500,21 +496,21 @@ func addV2TransactionFields(tx *txn, txns []types.V2Transaction, txnSeen map[typ
 			return fmt.Errorf("failed to scan for transaction ID: %w", err)
 		}
 
-		if err := addV2Attestations(tx, dbID, txn); err != nil {
+		if err := addV2Attestations(tx, dbID, txn.Attestations); err != nil {
 			return fmt.Errorf("failed to add attestations: %w", err)
-		} else if err := addV2SiacoinInputs(tx, dbID, txn); err != nil {
+		} else if err := addV2SiacoinInputs(tx, dbID, txn.SiacoinInputs); err != nil {
 			return fmt.Errorf("failed to add siacoin inputs: %w", err)
-		} else if err := addV2SiacoinOutputs(tx, dbID, txn); err != nil {
+		} else if err := addV2SiacoinOutputs(tx, dbID, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin outputs: %w", err)
-		} else if err := addV2SiafundInputs(tx, dbID, txn); err != nil {
+		} else if err := addV2SiafundInputs(tx, dbID, txn.SiafundInputs); err != nil {
 			return fmt.Errorf("failed to add siafund inputs: %w", err)
-		} else if err := addV2SiafundOutputs(tx, dbID, txn); err != nil {
+		} else if err := addV2SiafundOutputs(tx, dbID, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add siafund outputs: %w", err)
-		} else if err := addV2FileContracts(tx, dbID, txn); err != nil {
+		} else if err := addV2FileContracts(tx, dbID, txnID, txn); err != nil {
 			return fmt.Errorf("failed to add file contracts: %w", err)
-		} else if err := addV2FileContractRevisions(tx, dbID, txn); err != nil {
+		} else if err := addV2FileContractRevisions(tx, dbID, txn.FileContractRevisions); err != nil {
 			return fmt.Errorf("failed to add file contract revisions: %w", err)
-		} else if err := addV2FileContractResolutions(tx, dbID, txn); err != nil {
+		} else if err := addV2FileContractResolutions(tx, dbID, txn.FileContractResolutions); err != nil {
 			return fmt.Errorf("failed to add file contract resolutions: %w", err)
 		}
 	}

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -299,12 +299,12 @@ func getV2TransactionID(tx *txn, txnID types.TransactionID) (result int64, err e
 	return
 }
 
-func addV2SiacoinInputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+func addV2SiacoinInputs(tx *txn, txn types.V2Transaction) error {
 	if len(txn.SiacoinInputs) == 0 {
 		return nil
 	}
 
-	dbID, err := getV2TransactionID(tx, txnID)
+	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -323,11 +323,12 @@ func addV2SiacoinInputs(tx *txn, txnID types.TransactionID, txn types.V2Transact
 	return nil
 }
 
-func addV2SiacoinOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+func addV2SiacoinOutputs(tx *txn, txn types.V2Transaction) error {
 	if len(txn.SiacoinOutputs) == 0 {
 		return nil
 	}
 
+	txnID := txn.ID()
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -339,21 +340,20 @@ func addV2SiacoinOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transac
 	}
 	defer stmt.Close()
 
-	id := txn.ID()
 	for i := range txn.SiacoinOutputs {
-		if _, err := stmt.Exec(dbID, i, encode(txn.SiacoinOutputID(id, i))); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(txn.SiacoinOutputID(txnID, i))); err != nil {
 			return fmt.Errorf("addV2SiacoinOutputs: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2SiafundInputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+func addV2SiafundInputs(tx *txn, txn types.V2Transaction) error {
 	if len(txn.SiafundInputs) == 0 {
 		return nil
 	}
 
-	dbID, err := getV2TransactionID(tx, txnID)
+	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -372,11 +372,12 @@ func addV2SiafundInputs(tx *txn, txnID types.TransactionID, txn types.V2Transact
 	return nil
 }
 
-func addV2SiafundOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+func addV2SiafundOutputs(tx *txn, txn types.V2Transaction) error {
 	if len(txn.SiafundOutputs) == 0 {
 		return nil
 	}
 
+	txnID := txn.ID()
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -388,20 +389,20 @@ func addV2SiafundOutputs(tx *txn, txnID types.TransactionID, txn types.V2Transac
 	}
 	defer stmt.Close()
 
-	id := txn.ID()
 	for i := range txn.SiafundOutputs {
-		if _, err := stmt.Exec(dbID, i, encode(txn.SiafundOutputID(id, i))); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(txn.SiafundOutputID(txnID, i))); err != nil {
 			return fmt.Errorf("addV2SiafundOutputs: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2FileContracts(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+func addV2FileContracts(tx *txn, txn types.V2Transaction) error {
 	if len(txn.FileContracts) == 0 {
 		return nil
 	}
 
+	txnID := txn.ID()
 	dbID, err := getV2TransactionID(tx, txnID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
@@ -414,19 +415,19 @@ func addV2FileContracts(tx *txn, txnID types.TransactionID, txn types.V2Transact
 	defer stmt.Close()
 
 	for i, fc := range txn.FileContracts {
-		if _, err := stmt.Exec(dbID, i, encode(txn.V2FileContractID(txn.ID(), i)), encode(fc.RevisionNumber)); err != nil {
+		if _, err := stmt.Exec(dbID, i, encode(txn.V2FileContractID(txnID, i)), encode(fc.RevisionNumber)); err != nil {
 			return fmt.Errorf("addV2FileContracts: failed to execute statement: %w", err)
 		}
 	}
 	return nil
 }
 
-func addV2FileContractRevisions(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+func addV2FileContractRevisions(tx *txn, txn types.V2Transaction) error {
 	if len(txn.FileContractRevisions) == 0 {
 		return nil
 	}
 
-	dbID, err := getV2TransactionID(tx, txnID)
+	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -445,12 +446,12 @@ func addV2FileContractRevisions(tx *txn, txnID types.TransactionID, txn types.V2
 	return nil
 }
 
-func addV2FileContractResolutions(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+func addV2FileContractResolutions(tx *txn, txn types.V2Transaction) error {
 	if len(txn.FileContractResolutions) == 0 {
 		return nil
 	}
 
-	dbID, err := getV2TransactionID(tx, txnID)
+	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -493,12 +494,12 @@ func addV2FileContractResolutions(tx *txn, txnID types.TransactionID, txn types.
 	return nil
 }
 
-func addV2Attestations(tx *txn, txnID types.TransactionID, txn types.V2Transaction) error {
+func addV2Attestations(tx *txn, txn types.V2Transaction) error {
 	if len(txn.Attestations) == 0 {
 		return nil
 	}
 
-	dbID, err := getV2TransactionID(tx, txnID)
+	dbID, err := getV2TransactionID(tx, txn.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction ID: %w", err)
 	}
@@ -533,21 +534,21 @@ func addV2TransactionFields(tx *txn, txns []types.V2Transaction, v2TxnDBIds map[
 		// multiple of the same transaction in a block
 		v2TxnDBIds[txnID] = txnDBId{id: dbID.id, exist: true}
 
-		if err := addV2Attestations(tx, txnID, txn); err != nil {
+		if err := addV2Attestations(tx, txn); err != nil {
 			return fmt.Errorf("addV2TransactionFields: failed to add attestations: %w", err)
-		} else if err := addV2SiacoinInputs(tx, txnID, txn); err != nil {
+		} else if err := addV2SiacoinInputs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin inputs: %w", err)
-		} else if err := addV2SiacoinOutputs(tx, txnID, txn); err != nil {
+		} else if err := addV2SiacoinOutputs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add siacoin outputs: %w", err)
-		} else if err := addV2SiafundInputs(tx, txnID, txn); err != nil {
+		} else if err := addV2SiafundInputs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add siafund inputs: %w", err)
-		} else if err := addV2SiafundOutputs(tx, txnID, txn); err != nil {
+		} else if err := addV2SiafundOutputs(tx, txn); err != nil {
 			return fmt.Errorf("failed to add siafund outputs: %w", err)
-		} else if err := addV2FileContracts(tx, txnID, txn); err != nil {
+		} else if err := addV2FileContracts(tx, txn); err != nil {
 			return fmt.Errorf("failed to add file contracts: %w", err)
-		} else if err := addV2FileContractRevisions(tx, txnID, txn); err != nil {
+		} else if err := addV2FileContractRevisions(tx, txn); err != nil {
 			return fmt.Errorf("failed to add file contract revisions: %w", err)
-		} else if err := addV2FileContractResolutions(tx, txnID, txn); err != nil {
+		} else if err := addV2FileContractResolutions(tx, txn); err != nil {
 			return fmt.Errorf("failed to add file contract resolutions: %w", err)
 		}
 	}


### PR DESCRIPTION
Finish https://github.com/SiaFoundation/explored/issues/208 and remove the remaining maps that we used to map Sia IDs to internal database IDs.

christopher/clean-up-indexing-more:
```
----- latest commit (8946...) -----
BenchmarkApplyRevert/apply-4                 276       4194136 ns/op
BenchmarkApplyRevert/revert-4                 34      33399087 ns/op
```

master:
```
BenchmarkApplyRevert/apply-4                 248       4679242 ns/op
BenchmarkApplyRevert/revert-4                 33      33931566 ns/op
```