### PR TITLE
Add block time metrics

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -280,6 +280,12 @@ func (c *Client) HostMetrics() (resp explorer.HostMetrics, err error) {
 	return
 }
 
+// BlockTimeMetrics returns the average block time during various intervals.
+func (c *Client) BlockTimeMetrics() (resp explorer.BlockTimeMetrics, err error) {
+	err = c.c.GET(context.Background(), "/metrics/blocktime", &resp)
+	return
+}
+
 // Search returns what type of object an ID is.
 func (c *Client) Search(id string) (resp explorer.SearchType, err error) {
 	err = c.c.GET(context.Background(), fmt.Sprintf("/search/%s", id), &resp)

--- a/api/server.go
+++ b/api/server.go
@@ -299,6 +299,14 @@ func (s *server) hostMetricsHandler(jc jape.Context) {
 	jc.Encode(metrics)
 }
 
+func (s *server) blockTimeMetricsHandler(jc jape.Context) {
+	metrics, err := s.e.BlockTimeMetricsHandler()
+	if jc.Check("failed to get block time metrics", err) != nil {
+		return
+	}
+	jc.Encode(metrics)
+}
+
 func (s *server) blocksIDHandler(jc jape.Context) {
 	var id types.BlockID
 	if jc.DecodeParam("id", &id) != nil {
@@ -885,6 +893,7 @@ func NewServer(e Explorer, cm ChainManager, s Syncer, ex exchangerates.Source, a
 		"GET    /metrics/block":     srv.blocksMetricsHandler,
 		"GET    /metrics/block/:id": srv.blocksMetricsIDHandler,
 		"GET    /metrics/host":      srv.hostMetricsHandler,
+		"GET    /metrics/blocktime": srv.blockTimeMetricsHandler,
 
 		"POST   /hosts": srv.hostsHandler,
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -89,6 +89,7 @@ type Store interface {
 	Metrics(id types.BlockID) (Metrics, error)
 	LastSuccessScan() (time.Time, error)
 	HostMetrics() (HostMetrics, error)
+	BlockTimeMetrics() (BlockTimeMetrics, error)
 	Transactions(ids []types.TransactionID) ([]Transaction, error)
 	TransactionChainIndices(txid types.TransactionID, offset, limit uint64) ([]types.ChainIndex, error)
 	V2Transactions(ids []types.TransactionID) ([]V2Transaction, error)
@@ -317,6 +318,11 @@ func (e *Explorer) Metrics(id types.BlockID) (Metrics, error) {
 // HostMetrics returns various metrics about currently available hosts.
 func (e *Explorer) HostMetrics() (HostMetrics, error) {
 	return e.s.HostMetrics()
+}
+
+// BlockTimeMetrics returns the average block time during various intervals.
+func (e *Explorer) BlockTimeMetrics() (BlockTimeMetrics, error) {
+	return e.s.BlockTimeMetrics()
 }
 
 // Transactions returns the transactions with the specified IDs.

--- a/explorer/types.go
+++ b/explorer/types.go
@@ -605,3 +605,10 @@ type HostQuery struct {
 	AcceptContracts      *bool             `json:"acceptContracts,omitempty"`
 	Online               *bool             `json:"online,omitempty"`
 }
+
+// BlockTimeMetrics represents the average block time during various intervals.
+type BlockTimeMetrics struct {
+	Day   time.Duration
+	Week  time.Duration
+	Month time.Duration
+}

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -15,6 +15,7 @@ CREATE TABLE blocks (
 	v2_commitment BLOB
 );
 CREATE INDEX blocks_height_index ON blocks(height);
+CREATE INDEX blocks_timestamp_index ON blocks(timestamp);
 
 CREATE TABLE network_metrics (
 	block_id BLOB PRIMARY KEY REFERENCES blocks(id) NOT NULL,

--- a/persist/sqlite/metrics.go
+++ b/persist/sqlite/metrics.go
@@ -229,15 +229,11 @@ WITH recent_blocks AS (
     SELECT height, timestamp
     FROM blocks
     WHERE timestamp >= strftime('%s', 'now') - ?
-    ORDER BY height
-),
-differences AS (
-    SELECT b2.timestamp - b1.timestamp AS delta
-    FROM recent_blocks b1
-    JOIN recent_blocks b2 ON b2.height = b1.height + 1
 )
-SELECT ROUND(AVG(delta)) AS average_block_time
-FROM differences;`)
+SELECT ROUND(AVG(b2.timestamp - b1.timestamp)) AS average_block_time
+FROM recent_blocks b1
+JOIN recent_blocks b2 ON b2.height = b1.height + 1;
+`)
 		if err != nil {
 			return fmt.Errorf("failed to prepare statement: %w", err)
 		}

--- a/persist/sqlite/metrics_test.go
+++ b/persist/sqlite/metrics_test.go
@@ -456,7 +456,7 @@ func BenchmarkBlockTimeMetrics(b *testing.B) {
 		var parentID types.BlockID
 		nonce, leafIndex := encode(uint64(0)), encode(uint64(0))
 		for i := range 500000 {
-			if i % 10000 == 0 {
+			if i%10000 == 0 {
 				b.Log("Adding block:", i)
 			}
 			id := types.BlockID(frand.Entropy256())

--- a/persist/sqlite/metrics_test.go
+++ b/persist/sqlite/metrics_test.go
@@ -2,12 +2,14 @@ package sqlite
 
 import (
 	"testing"
+	"time"
 
 	"go.sia.tech/core/consensus"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/explored/explorer"
 	"go.sia.tech/explored/internal/testutil"
+	"lukechampine.com/frand"
 )
 
 func TestMetrics(t *testing.T) {
@@ -435,4 +437,53 @@ func TestV2Metrics(t *testing.T) {
 	n.revertBlock(t)
 
 	assertMetrics(metricsGenesis)
+}
+
+func BenchmarkBlockTimeMetrics(b *testing.B) {
+	n := newTestChain(b, false, nil)
+
+	const month = 30 * 24 * time.Hour
+	const blockTime = 10 * time.Minute
+
+	now := time.Now().Add(-month)
+	err := n.db.transaction(func(tx *txn) error {
+		blockStmt, err := tx.Prepare(`INSERT INTO blocks(id, height, parent_id, nonce, timestamp, leaf_index) VALUES (?, ?, ?, ?, ?, ?)`)
+		if err != nil {
+			return err
+		}
+		defer blockStmt.Close()
+
+		var parentID types.BlockID
+		nonce, leafIndex := encode(uint64(0)), encode(uint64(0))
+		for i := range 500000 {
+			if i % 10000 == 0 {
+				b.Log("Adding block:", i)
+			}
+			id := types.BlockID(frand.Entropy256())
+			if _, err := blockStmt.Exec(encode(id), i, encode(parentID), nonce, encode(now), leafIndex); err != nil {
+				b.Fatal(err)
+			}
+
+			parentID = id
+			now = now.Add(blockTime)
+		}
+		return nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for b.Loop() {
+		blockTimes, err := n.db.BlockTimeMetrics()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if blockTimes.Day != blockTime {
+			b.Fatalf("expected %v average block time for past day, got %v", blockTime, blockTimes.Day)
+		} else if blockTimes.Week != blockTime {
+			b.Fatalf("expected %v average block time for past week, got %v", blockTime, blockTimes.Week)
+		} else if blockTimes.Month != blockTime {
+			b.Fatalf("expected %v average block time for past month, got %v", blockTime, blockTimes.Month)
+		}
+	}
 }

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -36,8 +36,14 @@ func migrateV4(txn *txn, log *zap.Logger) error {
 	return nil
 }
 
+func migrateV5(txn *txn, _ *zap.Logger) error {
+	_, err := txn.Exec(`CREATE INDEX IF NOT EXISTS blocks_timestamp_index ON blocks(timestamp);`)
+	return err
+}
+
 var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateV2,
 	migrateV3,
 	migrateV4,
+	migrateV5,
 }


### PR DESCRIPTION
Add `BlockTimeMetrics` function to store to return average block time for the past day, week, and month.

(with 500k blocks)
```
BenchmarkBlockTimeMetrics-4            1        1125174435 ns/op
```

I tried a number of variants on the query including with the built-in `LAG` and this had the best performance.  May need some sort of caching layer.