### PR TITLE
Be more consistent with error messages

### DIFF
--- a/explorer/update.go
+++ b/explorer/update.go
@@ -470,10 +470,7 @@ func revertChainUpdate(tx UpdateTx, cru chain.RevertUpdate, revertedIndex types.
 	}
 	state.Metrics.Index = revertedIndex
 
-	if err := tx.RevertIndex(state); err != nil {
-		return fmt.Errorf("failed to revert block: %w", err)
-	}
-	return nil
+	return tx.RevertIndex(state)
 }
 
 func updateMetrics(tx UpdateTx, s UpdateState, metrics Metrics) (Metrics, error) {

--- a/explorer/update.go
+++ b/explorer/update.go
@@ -325,7 +325,10 @@ func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate) error {
 	state.Metrics.SiafundTaxRevenue = cau.State.SiafundTaxRevenue
 	state.Metrics.NumLeaves = cau.State.Elements.NumLeaves
 
-	return tx.ApplyIndex(state)
+	if err := tx.ApplyIndex(state); err != nil {
+		return fmt.Errorf("failed to apply block: ApplyIndex: %w", err)
+	}
+	return nil
 }
 
 // revertChainUpdate atomically reverts a chain update from a store
@@ -467,7 +470,10 @@ func revertChainUpdate(tx UpdateTx, cru chain.RevertUpdate, revertedIndex types.
 	}
 	state.Metrics.Index = revertedIndex
 
-	return tx.RevertIndex(state)
+	if err := tx.RevertIndex(state); err != nil {
+		return fmt.Errorf("failed to revert block: RevertIndex: %w", err)
+	}
+	return nil
 }
 
 func updateMetrics(tx UpdateTx, s UpdateState, metrics Metrics) (Metrics, error) {

--- a/explorer/update.go
+++ b/explorer/update.go
@@ -318,7 +318,7 @@ func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate) error {
 	}
 	state.Metrics, err = updateMetrics(tx, state, prevMetrics)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to update metrics: %w", err)
 	}
 	state.Metrics.Index = cau.State.Index
 	state.Metrics.Difficulty = cau.State.Difficulty
@@ -326,7 +326,7 @@ func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate) error {
 	state.Metrics.NumLeaves = cau.State.Elements.NumLeaves
 
 	if err := tx.ApplyIndex(state); err != nil {
-		return fmt.Errorf("failed to apply block: ApplyIndex: %w", err)
+		return fmt.Errorf("failed to apply block: %w", err)
 	}
 	return nil
 }
@@ -471,7 +471,7 @@ func revertChainUpdate(tx UpdateTx, cru chain.RevertUpdate, revertedIndex types.
 	state.Metrics.Index = revertedIndex
 
 	if err := tx.RevertIndex(state); err != nil {
-		return fmt.Errorf("failed to revert block: RevertIndex: %w", err)
+		return fmt.Errorf("failed to revert block: %w", err)
 	}
 	return nil
 }

--- a/persist/sqlite/addresses.go
+++ b/persist/sqlite/addresses.go
@@ -19,14 +19,14 @@ LIMIT $2 OFFSET $3;`
 
 	rows, err := tx.Query(query, encode(address), limit, offset)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to query address event IDs: %w", err)
 	}
 	defer rows.Close()
 
 	for rows.Next() {
 		var id int64
 		if err := rows.Scan(&id); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to scan address ID: %w", err)
 		}
 		eventIDs = append(eventIDs, id)
 	}
@@ -78,7 +78,7 @@ func (s *Store) AddressEvents(address types.Address, offset, limit uint64) (even
 	err = s.transaction(func(tx *txn) error {
 		dbIDs, err := getAddressEvents(tx, address, offset, limit)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get address event IDs: %w", err)
 		}
 
 		events, err = getEventsByID(tx, dbIDs)

--- a/persist/sqlite/blocks.go
+++ b/persist/sqlite/blocks.go
@@ -33,12 +33,12 @@ func (s *Store) Block(id types.BlockID) (result explorer.Block, err error) {
 			// get block transaction IDs
 			transactionIDs, err := blockV2TransactionIDs(tx, id)
 			if err != nil {
-				return fmt.Errorf("failed to get block transaction IDs: %w", err)
+				return fmt.Errorf("failed to get block v2 transaction IDs: %w", err)
 			}
 
 			result.V2.Transactions, err = getV2Transactions(tx, transactionIDs)
 			if err != nil {
-				return fmt.Errorf("failed to get transactions: %w", err)
+				return fmt.Errorf("failed to get v2 transactions: %w", err)
 			}
 		}
 

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -191,7 +191,7 @@ func addFileContracts(tx *txn, dbID int64, txn types.Transaction) error {
 
 	for i, fc := range txn.FileContracts {
 		if _, err := stmt.Exec(dbID, i, encode(txn.FileContractID(i)), encode(fc.RevisionNumber)); err != nil {
-			return fmt.Errorf("failed to execute transaction_file_contracts statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -325,25 +325,25 @@ func addTransactionFields(tx *txn, txns []types.Transaction, txnExist map[types.
 		}
 
 		if err := addMinerFees(tx, dbID, txn.MinerFees); err != nil {
-			return fmt.Errorf("failed to add miner fees: addMinerFees: %w", err)
+			return fmt.Errorf("failed to add miner fees: %w", err)
 		} else if err := addArbitraryData(tx, dbID, txn.ArbitraryData); err != nil {
-			return fmt.Errorf("failed to add arbitrary data: addArbitraryData: %w", err)
+			return fmt.Errorf("failed to add arbitrary data: %w", err)
 		} else if err := addSignatures(tx, dbID, txn.Signatures); err != nil {
-			return fmt.Errorf("failed to add signatures: addSignatures: %w", err)
+			return fmt.Errorf("failed to add signatures: %w", err)
 		} else if err := addSiacoinInputs(tx, dbID, txn.SiacoinInputs); err != nil {
-			return fmt.Errorf("failed to add siacoin inputs: addSiacoinInputs: %w", err)
+			return fmt.Errorf("failed to add siacoin inputs: %w", err)
 		} else if err := addSiacoinOutputs(tx, dbID, txn); err != nil {
-			return fmt.Errorf("failed to add siacoin outputs: addSiacoinOutputs: %w", err)
+			return fmt.Errorf("failed to add siacoin outputs: %w", err)
 		} else if err := addSiafundInputs(tx, dbID, txn.SiafundInputs); err != nil {
-			return fmt.Errorf("failed to add siafund inputs: addSiafundInputs: %w", err)
+			return fmt.Errorf("failed to add siafund inputs: %w", err)
 		} else if err := addSiafundOutputs(tx, dbID, txn); err != nil {
-			return fmt.Errorf("failed to add siafund outputs: addSiafundOutputs: %w", err)
+			return fmt.Errorf("failed to add siafund outputs: %w", err)
 		} else if err := addFileContracts(tx, dbID, txn); err != nil {
-			return fmt.Errorf("failed to add file contracts: addFileContracts: %w", err)
+			return fmt.Errorf("failed to add file contracts: %w", err)
 		} else if err := addFileContractRevisions(tx, dbID, txn.FileContractRevisions); err != nil {
-			return fmt.Errorf("failed to add file contract revisions: addFileContractRevisions: %w", err)
+			return fmt.Errorf("failed to add file contract revisions: %w", err)
 		} else if err := addStorageProofs(tx, dbID, txn.StorageProofs); err != nil {
-			return fmt.Errorf("failed to add storage proofs: addStorageProofs: %w", err)
+			return fmt.Errorf("failed to add storage proofs: %w", err)
 		}
 	}
 
@@ -1008,19 +1008,19 @@ func (ut *updateTx) Metrics(height uint64) (explorer.Metrics, error) {
 
 func (ut *updateTx) ApplyIndex(state explorer.UpdateState) error {
 	if err := addBlock(ut.tx, state.Block, state.ChainIndexElement, state.Metrics.Index.Height); err != nil {
-		return fmt.Errorf("failed to add block: addBlock: %w", err)
+		return fmt.Errorf("failed to add block: %w", err)
 	} else if err := updateMaturedBalances(ut.tx, false, state.Metrics.Index.Height); err != nil {
-		return fmt.Errorf("failed to update matured balances: updateMaturedBalances: %w", err)
+		return fmt.Errorf("failed to update matured balances: %w", err)
 	}
 
 	txnSeen, err := addTransactions(ut.tx, state.Block.ID(), state.Block.Transactions)
 	if err != nil {
-		return fmt.Errorf("failed to add transactions: addTransactions: %w", err)
+		return fmt.Errorf("failed to add transactions: %w", err)
 	}
 
 	v2TxnSeen, err := addV2Transactions(ut.tx, state.Block.ID(), state.Block.V2Transactions())
 	if err != nil {
-		return fmt.Errorf("failed to add v2 transactions: addV2Transactions: %w", err)
+		return fmt.Errorf("failed to add v2 transactions: %w", err)
 	}
 
 	if err := addSiacoinElements(
@@ -1029,38 +1029,38 @@ func (ut *updateTx) ApplyIndex(state explorer.UpdateState) error {
 		append(state.SpentSiacoinElements, state.EphemeralSiacoinElements...),
 		state.NewSiacoinElements,
 	); err != nil {
-		return fmt.Errorf("failed to add siacoin outputs: addSiacoinElements: %w", err)
+		return fmt.Errorf("failed to add siacoin outputs: %w", err)
 	} else if err := addSiafundElements(
 		ut.tx,
 		state.Metrics.Index,
 		append(state.SpentSiafundElements, state.EphemeralSiafundElements...),
 		state.NewSiafundElements,
 	); err != nil {
-		return fmt.Errorf("failed to add siafund outputs: addSiafundElements: %w", err)
+		return fmt.Errorf("failed to add siafund outputs: %w", err)
 	} else if err := updateFileContractElements(ut.tx, false, state.Metrics.Index, state.Block, state.FileContractElements); err != nil {
-		return fmt.Errorf("failed to add file contracts: updateFileContractElements: %w", err)
+		return fmt.Errorf("failed to add file contracts: %w", err)
 	} else if err := updateV2FileContractElements(ut.tx, false, state.Metrics.Index, state.Block, state.V2FileContractElements); err != nil {
-		return fmt.Errorf("failed to add v2 file contracts: updateV2FileContractElements: %w", err)
+		return fmt.Errorf("failed to add v2 file contracts: %w", err)
 	} else if err := addTransactionFields(ut.tx, state.Block.Transactions, txnSeen); err != nil {
-		return fmt.Errorf("failed to add transaction fields: addTransactionFields: %w", err)
+		return fmt.Errorf("failed to add transaction fields: %w", err)
 	} else if err := addV2TransactionFields(ut.tx, state.Block.V2Transactions(), v2TxnSeen); err != nil {
-		return fmt.Errorf("failed to add v2 transaction fields: addV2TransactionFields: %w", err)
+		return fmt.Errorf("failed to add v2 transaction fields: %w", err)
 	} else if err := updateBalances(ut.tx, state.Metrics.Index.Height, state.SpentSiacoinElements, state.NewSiacoinElements, state.SpentSiafundElements, state.NewSiafundElements); err != nil {
-		return fmt.Errorf("failed to update balances: updateBalances: %w", err)
+		return fmt.Errorf("failed to update balances: %w", err)
 	} else if err := addMinerPayouts(ut.tx, state.Block.ID(), state.Block.MinerPayouts); err != nil {
-		return fmt.Errorf("failed to add miner payouts: addMinerPayouts: %w", err)
+		return fmt.Errorf("failed to add miner payouts: %w", err)
 	} else if err := updateStateTree(ut.tx, state.TreeUpdates); err != nil {
-		return fmt.Errorf("failed to update state tree: updateStateTree: %w", err)
+		return fmt.Errorf("failed to update state tree: %w", err)
 	} else if err := addMetrics(ut.tx, state); err != nil {
-		return fmt.Errorf("failed to update metrics: addMetrics: %w", err)
+		return fmt.Errorf("failed to update metrics: %w", err)
 	} else if err := addHostAnnouncements(ut.tx, state.Block.Timestamp, state.HostAnnouncements, state.V2HostAnnouncements); err != nil {
-		return fmt.Errorf("failed to add host announcements: addHostAnnouncements: %w", err)
+		return fmt.Errorf("failed to add host announcements: %w", err)
 	} else if err := updateFileContractIndices(ut.tx, false, state.Metrics.Index, state.FileContractElements); err != nil {
-		return fmt.Errorf("failed to update file contract element indices: updateFileContractIndices: %w", err)
+		return fmt.Errorf("failed to update file contract element indices: %w", err)
 	} else if err := updateV2FileContractIndices(ut.tx, false, state.Metrics.Index, state.V2FileContractElements); err != nil {
 		return fmt.Errorf("failed to update v2 file contract element indices: updateV2FileContractIndices: %w", err)
 	} else if err := addEvents(ut.tx, state.Block.ID(), state.Events); err != nil {
-		return fmt.Errorf("failed to add events: addEvents: %w", err)
+		return fmt.Errorf("failed to add events: %w", err)
 	}
 
 	return nil
@@ -1228,7 +1228,7 @@ func (s *Store) ResetChainState() error {
 		if _, err := tx.Exec(`PRAGMA defer_foreign_keys=ON`); err != nil {
 			return fmt.Errorf("failed to defer foreign key checks: %w", err)
 		} else if err := resetChainState(tx, s.log, int64(len(migrations)+1)); err != nil {
-			return fmt.Errorf("failed to reset chain state: resetChainState: %w", err)
+			return fmt.Errorf("failed to reset chain state: %w", err)
 		}
 		return nil
 	}); err != nil {

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -487,6 +487,9 @@ func updateMaturedBalances(tx *txn, revert bool, height uint64) error {
 		scos = append(scos, sco)
 		addressList[sco.Address] = struct{}{}
 	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to retrieve maturing output rows: %w", err)
+	}
 
 	balanceRowsStmt, err := tx.Prepare(`SELECT siacoin_balance, immature_siacoin_balance
         FROM address_balance

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -32,13 +32,13 @@ func addBlock(tx *txn, b types.Block, cie types.ChainIndexElement, height uint64
 func addMinerPayouts(tx *txn, bid types.BlockID, scos []types.SiacoinOutput) error {
 	stmt, err := tx.Prepare(`INSERT INTO miner_payouts(block_id, block_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?));`)
 	if err != nil {
-		return fmt.Errorf("addMinerPayouts: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i := range scos {
 		if _, err := stmt.Exec(encode(bid), i, encode(bid.MinerOutputID(i))); err != nil {
-			return fmt.Errorf("addMinerPayouts: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -51,13 +51,13 @@ func addMinerFees(tx *txn, dbID int64, minerFees []types.Currency) error {
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_miner_fees(transaction_id, transaction_order, fee) VALUES (?, ?, ?)`)
 	if err != nil {
-		return fmt.Errorf("addMinerFees: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, fee := range minerFees {
 		if _, err := stmt.Exec(dbID, i, encode(fee)); err != nil {
-			return fmt.Errorf("addMinerFees: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -70,13 +70,13 @@ func addArbitraryData(tx *txn, dbID int64, arbitraryData [][]byte) error {
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_arbitrary_data(transaction_id, transaction_order, data) VALUES (?, ?, ?)`)
 	if err != nil {
-		return fmt.Errorf("addArbitraryData: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, arb := range arbitraryData {
 		if _, err := stmt.Exec(dbID, i, arb); err != nil {
-			return fmt.Errorf("addArbitraryData: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -89,13 +89,13 @@ func addSignatures(tx *txn, dbID int64, signatures []types.TransactionSignature)
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_signatures(transaction_id, transaction_order, parent_id, public_key_index, timelock, covered_fields, signature) VALUES (?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
-		return fmt.Errorf("addSignatures: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, sig := range signatures {
 		if _, err := stmt.Exec(dbID, i, encode(sig.ParentID), sig.PublicKeyIndex, encode(sig.Timelock), encode(sig.CoveredFields), sig.Signature); err != nil {
-			return fmt.Errorf("addSignatures: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -108,13 +108,13 @@ func addSiacoinInputs(tx *txn, dbID int64, siacoinInputs []types.SiacoinInput) e
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siacoin_inputs(transaction_id, transaction_order, unlock_conditions, parent_id) VALUES (?, ?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
 	if err != nil {
-		return fmt.Errorf("addSiacoinInputs: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, sci := range siacoinInputs {
 		if _, err := stmt.Exec(dbID, i, encode(sci.UnlockConditions), encode(sci.ParentID)); err != nil {
-			return fmt.Errorf("addSiacoinInputs: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -127,13 +127,13 @@ func addSiacoinOutputs(tx *txn, dbID int64, txn types.Transaction) error {
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siacoin_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
 	if err != nil {
-		return fmt.Errorf("addSiacoinOutputs: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i := range txn.SiacoinOutputs {
 		if _, err := stmt.Exec(dbID, i, encode(txn.SiacoinOutputID(i))); err != nil {
-			return fmt.Errorf("addSiacoinOutputs: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -146,13 +146,13 @@ func addSiafundInputs(tx *txn, dbID int64, siafundInputs []types.SiafundInput) e
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siafund_inputs(transaction_id, transaction_order, unlock_conditions, claim_address, parent_id) VALUES (?, ?, ?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
 	if err != nil {
-		return fmt.Errorf("addSiafundInputs: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, sfi := range siafundInputs {
 		if _, err := stmt.Exec(dbID, i, encode(sfi.UnlockConditions), encode(sfi.ClaimAddress), encode(sfi.ParentID)); err != nil {
-			return fmt.Errorf("addSiafundInputs: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 
@@ -166,13 +166,13 @@ func addSiafundOutputs(tx *txn, dbID int64, txn types.Transaction) error {
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_siafund_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
 	if err != nil {
-		return fmt.Errorf("addSiafundOutputs: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i := range txn.SiafundOutputs {
 		if _, err := stmt.Exec(dbID, i, encode(txn.SiafundOutputID(i))); err != nil {
-			return fmt.Errorf("addSiafundOutputs: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -185,13 +185,13 @@ func addFileContracts(tx *txn, dbID int64, txn types.Transaction) error {
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, (SELECT id FROM file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
-		return fmt.Errorf("addFileContracts: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, fc := range txn.FileContracts {
 		if _, err := stmt.Exec(dbID, i, encode(txn.FileContractID(i)), encode(fc.RevisionNumber)); err != nil {
-			return fmt.Errorf("addFileContracts: failed to execute transaction_file_contracts statement: %w", err)
+			return fmt.Errorf("failed to execute transaction_file_contracts statement: %w", err)
 		}
 	}
 	return nil
@@ -204,13 +204,13 @@ func addFileContractRevisions(tx *txn, dbID int64, fileContractRevisions []types
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_file_contract_revisions(transaction_id, transaction_order, parent_id, unlock_conditions, contract_id) VALUES (?, ?, ?, ?, (SELECT id FROM file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
-		return fmt.Errorf("addFileContractRevisions: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, fcr := range fileContractRevisions {
 		if _, err := stmt.Exec(dbID, i, encode(fcr.ParentID), encode(fcr.UnlockConditions), encode(fcr.ParentID), encode(fcr.FileContract.RevisionNumber)); err != nil {
-			return fmt.Errorf("addFileContractRevisions: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 
@@ -224,13 +224,13 @@ func addStorageProofs(tx *txn, dbID int64, storageProofs []types.StorageProof) e
 
 	stmt, err := tx.Prepare(`INSERT INTO transaction_storage_proofs(transaction_id, transaction_order, parent_id, leaf, proof) VALUES (?, ?, ?, ?, ?)`)
 	if err != nil {
-		return fmt.Errorf("addStorageProofs: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, proof := range storageProofs {
 		if _, err := stmt.Exec(dbID, i, encode(proof.ParentID), proof.Leaf[:], encode(proof.Proof)); err != nil {
-			return fmt.Errorf("addStorageProofs: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -325,25 +325,25 @@ func addTransactionFields(tx *txn, txns []types.Transaction, txnExist map[types.
 		}
 
 		if err := addMinerFees(tx, dbID, txn.MinerFees); err != nil {
-			return fmt.Errorf("failed to add miner fees: %w", err)
+			return fmt.Errorf("failed to add miner fees: addMinerFees: %w", err)
 		} else if err := addArbitraryData(tx, dbID, txn.ArbitraryData); err != nil {
-			return fmt.Errorf("failed to add arbitrary data: %w", err)
+			return fmt.Errorf("failed to add arbitrary data: addArbitraryData: %w", err)
 		} else if err := addSignatures(tx, dbID, txn.Signatures); err != nil {
-			return fmt.Errorf("failed to add signatures: %w", err)
+			return fmt.Errorf("failed to add signatures: addSignatures: %w", err)
 		} else if err := addSiacoinInputs(tx, dbID, txn.SiacoinInputs); err != nil {
-			return fmt.Errorf("failed to add siacoin inputs: %w", err)
+			return fmt.Errorf("failed to add siacoin inputs: addSiacoinInputs: %w", err)
 		} else if err := addSiacoinOutputs(tx, dbID, txn); err != nil {
-			return fmt.Errorf("failed to add siacoin outputs: %w", err)
+			return fmt.Errorf("failed to add siacoin outputs: addSiacoinOutputs: %w", err)
 		} else if err := addSiafundInputs(tx, dbID, txn.SiafundInputs); err != nil {
-			return fmt.Errorf("failed to add siafund inputs: %w", err)
+			return fmt.Errorf("failed to add siafund inputs: addSiafundInputs: %w", err)
 		} else if err := addSiafundOutputs(tx, dbID, txn); err != nil {
-			return fmt.Errorf("failed to add siafund outputs: %w", err)
+			return fmt.Errorf("failed to add siafund outputs: addSiafundOutputs: %w", err)
 		} else if err := addFileContracts(tx, dbID, txn); err != nil {
-			return fmt.Errorf("failed to add file contract: %w", err)
+			return fmt.Errorf("failed to add file contracts: addFileContracts: %w", err)
 		} else if err := addFileContractRevisions(tx, dbID, txn.FileContractRevisions); err != nil {
-			return fmt.Errorf("failed to add file contract revisions: %w", err)
+			return fmt.Errorf("failed to add file contract revisions: addFileContractRevisions: %w", err)
 		} else if err := addStorageProofs(tx, dbID, txn.StorageProofs); err != nil {
-			return fmt.Errorf("failed to add storage proofs: %w", err)
+			return fmt.Errorf("failed to add storage proofs: addStorageProofs: %w", err)
 		}
 	}
 
@@ -398,14 +398,14 @@ func updateBalances(tx *txn, height uint64, spentSiacoinElements, newSiacoinElem
         FROM address_balance
         WHERE address = ?`)
 	if err != nil {
-		return fmt.Errorf("updateBalances: failed to prepare address_balance statement: %w", err)
+		return fmt.Errorf("failed to prepare address_balance statement: %w", err)
 	}
 	defer balanceRowsStmt.Close()
 
 	for addr := range addresses {
 		var bal balance
 		if err := balanceRowsStmt.QueryRow(encode(addr)).Scan(decode(&bal.sc), decode(&bal.immatureSC), decode(&bal.sf)); err != nil && err != sql.ErrNoRows {
-			return fmt.Errorf("updateBalances: failed to scan balance: %w", err)
+			return fmt.Errorf("failed to scan balance: %w", err)
 		}
 		addresses[addr] = bal
 	}
@@ -448,13 +448,13 @@ func updateBalances(tx *txn, height uint64, spentSiacoinElements, newSiacoinElem
        ON CONFLICT(address)
        DO UPDATE set siacoin_balance = ?, immature_siacoin_balance = ?, siafund_balance = ?`)
 	if err != nil {
-		return fmt.Errorf("updateBalances: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for addr, bal := range addresses {
 		if _, err := stmt.Exec(encode(addr), encode(bal.sc), encode(bal.immatureSC), encode(bal.sf), encode(bal.sc), encode(bal.immatureSC), encode(bal.sf)); err != nil {
-			return fmt.Errorf("updateBalances: failed to exec statement: %w", err)
+			return fmt.Errorf("failed to exec statement: %w", err)
 		}
 		// log.Println(addr, "=", bal.sc)
 	}
@@ -473,7 +473,7 @@ func updateMaturedBalances(tx *txn, revert bool, height uint64) error {
 		        FROM siacoin_elements
 		        WHERE maturity_height = ?`, height)
 	if err != nil {
-		return fmt.Errorf("updateMaturedBalances: failed to query siacoin_elements: %w", err)
+		return fmt.Errorf("failed to query siacoin_elements: %w", err)
 	}
 	defer rows.Close()
 
@@ -482,7 +482,7 @@ func updateMaturedBalances(tx *txn, revert bool, height uint64) error {
 	for rows.Next() {
 		var sco types.SiacoinOutput
 		if err := rows.Scan(decode(&sco.Address), decode(&sco.Value)); err != nil {
-			return fmt.Errorf("updateMaturedBalances: failed to scan maturing outputs: %w", err)
+			return fmt.Errorf("failed to scan maturing outputs: %w", err)
 		}
 		scos = append(scos, sco)
 		addressList[sco.Address] = struct{}{}
@@ -492,7 +492,7 @@ func updateMaturedBalances(tx *txn, revert bool, height uint64) error {
         FROM address_balance
         WHERE address = ?`)
 	if err != nil {
-		return fmt.Errorf("updateMaturedBalances: failed to prepare address_balance statement: %w", err)
+		return fmt.Errorf("failed to prepare address_balance statement: %w", err)
 	}
 	defer balanceRowsStmt.Close()
 
@@ -500,7 +500,7 @@ func updateMaturedBalances(tx *txn, revert bool, height uint64) error {
 	for addr := range addressList {
 		var bal balance
 		if err := balanceRowsStmt.QueryRow(encode(addr)).Scan(decode(&bal.sc), decode(&bal.immatureSC)); err != nil {
-			return fmt.Errorf("updateMaturedBalances: failed to scan balance: %w", err)
+			return fmt.Errorf("failed to scan balance: %w", err)
 		}
 		addresses[addr] = bal
 	}
@@ -524,14 +524,14 @@ func updateMaturedBalances(tx *txn, revert bool, height uint64) error {
     ON CONFLICT(address)
     DO UPDATE set siacoin_balance = ?, immature_siacoin_balance = ?`)
 	if err != nil {
-		return fmt.Errorf("updateMaturedBalances: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	initialSF := encode(uint64(0))
 	for addr, bal := range addresses {
 		if _, err := stmt.Exec(encode(addr), encode(bal.sc), encode(bal.immatureSC), initialSF, encode(bal.sc), encode(bal.immatureSC)); err != nil {
-			return fmt.Errorf("updateMaturedBalances: failed to exec statement: %w", err)
+			return fmt.Errorf("failed to exec statement: %w", err)
 		}
 	}
 
@@ -561,13 +561,13 @@ func addSiacoinElements(tx *txn, index types.ChainIndex, spentElements, newEleme
                 ON CONFLICT (output_id)
                 DO UPDATE SET leaf_index = ?, spent_index = NULL;`)
 		if err != nil {
-			return fmt.Errorf("addSiacoinElements: failed to prepare siacoin_elements statement: %w", err)
+			return fmt.Errorf("failed to prepare siacoin_elements statement: %w", err)
 		}
 		defer stmt.Close()
 
 		for _, sce := range newElements {
 			if _, err := stmt.Exec(encode(sce.ID), encode(index.ID), encode(sce.StateElement.LeafIndex), int(sce.Source), sce.MaturityHeight, encode(sce.SiacoinOutput.Address), encode(sce.SiacoinOutput.Value), encode(sce.StateElement.LeafIndex)); err != nil {
-				return fmt.Errorf("addSiacoinElements: failed to execute siacoin_elements statement: %w", err)
+				return fmt.Errorf("failed to execute siacoin_elements statement: %w", err)
 			}
 		}
 	}
@@ -577,13 +577,13 @@ func addSiacoinElements(tx *txn, index types.ChainIndex, spentElements, newEleme
                 ON CONFLICT (output_id)
                 DO UPDATE SET spent_index = ?, leaf_index = ?;`)
 		if err != nil {
-			return fmt.Errorf("addSiacoinElements: failed to prepare siacoin_elements statement: %w", err)
+			return fmt.Errorf("failed to prepare siacoin_elements statement: %w", err)
 		}
 		defer stmt.Close()
 
 		for _, sce := range spentElements {
 			if _, err := stmt.Exec(encode(sce.ID), encode(index.ID), encode(sce.StateElement.LeafIndex), encode(index), int(sce.Source), sce.MaturityHeight, encode(sce.SiacoinOutput.Address), encode(sce.SiacoinOutput.Value), encode(index), encode(sce.StateElement.LeafIndex)); err != nil {
-				return fmt.Errorf("addSiacoinElements: failed to execute siacoin_elements statement: %w", err)
+				return fmt.Errorf("failed to execute siacoin_elements statement: %w", err)
 			}
 		}
 	}
@@ -598,13 +598,13 @@ func addSiafundElements(tx *txn, index types.ChainIndex, spentElements, newEleme
             ON CONFLICT
             DO UPDATE SET leaf_index = ?, spent_index = NULL`)
 		if err != nil {
-			return fmt.Errorf("addSiafundElements: failed to prepare siafund_elements statement: %w", err)
+			return fmt.Errorf("failed to prepare siafund_elements statement: %w", err)
 		}
 		defer stmt.Close()
 
 		for _, sfe := range newElements {
 			if _, err := stmt.Exec(encode(sfe.ID), encode(index.ID), encode(sfe.StateElement.LeafIndex), encode(sfe.ClaimStart), encode(sfe.SiafundOutput.Address), encode(sfe.SiafundOutput.Value), encode(sfe.StateElement.LeafIndex)); err != nil {
-				return fmt.Errorf("addSiafundElements: failed to execute siafund_elements statement: %w", err)
+				return fmt.Errorf("failed to execute siafund_elements statement: %w", err)
 			}
 		}
 	}
@@ -614,13 +614,13 @@ func addSiafundElements(tx *txn, index types.ChainIndex, spentElements, newEleme
             ON CONFLICT
             DO UPDATE SET leaf_index = ?, spent_index = ?`)
 		if err != nil {
-			return fmt.Errorf("addSiafundElements: failed to prepare siafund_elements statement: %w", err)
+			return fmt.Errorf("failed to prepare siafund_elements statement: %w", err)
 		}
 		defer stmt.Close()
 
 		for _, sfe := range spentElements {
 			if _, err := stmt.Exec(encode(sfe.ID), encode(index.ID), encode(sfe.StateElement.LeafIndex), encode(index), encode(sfe.ClaimStart), encode(sfe.SiafundOutput.Address), encode(sfe.SiafundOutput.Value), encode(sfe.StateElement.LeafIndex), encode(index)); err != nil {
-				return fmt.Errorf("addSiafundElements: failed to execute siafund_elements statement: %w", err)
+				return fmt.Errorf("failed to execute siafund_elements statement: %w", err)
 			}
 		}
 	}
@@ -741,7 +741,7 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
         DO UPDATE SET leaf_index = ?
         RETURNING id;`)
 	if err != nil {
-		return fmt.Errorf("updateFileContractElements: failed to prepare main statement: %w", err)
+		return fmt.Errorf("failed to prepare main statement: %w", err)
 	}
 	defer stmt.Close()
 
@@ -750,19 +750,19 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
     ON CONFLICT (contract_id)
     DO UPDATE SET resolved = EXCLUDED.resolved, valid = EXCLUDED.valid, contract_element_id = ?, ed25519_renter_key = COALESCE(?, ed25519_renter_key), ed25519_host_key = COALESCE(?, ed25519_host_key), confirmation_height = COALESCE(?, confirmation_height), confirmation_block_id = COALESCE(?, confirmation_block_id), confirmation_transaction_id = COALESCE(?, confirmation_transaction_id)`)
 	if err != nil {
-		return fmt.Errorf("updateFileContractElements: failed to prepare last_contract_revision statement: %w", err)
+		return fmt.Errorf("failed to prepare last_contract_revision statement: %w", err)
 	}
 	defer revisionStmt.Close()
 
 	validOutputsStmt, err := tx.Prepare(`INSERT INTO file_contract_valid_proof_outputs(contract_id, contract_order, id, address, value) VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING`)
 	if err != nil {
-		return fmt.Errorf("addFileContracts: failed to prepare valid proof outputs statement: %w", err)
+		return fmt.Errorf("failed to prepare valid proof outputs statement: %w", err)
 	}
 	defer validOutputsStmt.Close()
 
 	missedOutputsStmt, err := tx.Prepare(`INSERT INTO file_contract_missed_proof_outputs(contract_id, contract_order, id, address, value) VALUES (?, ?, ?, ?, ?)  ON CONFLICT DO NOTHING`)
 	if err != nil {
-		return fmt.Errorf("addFileContracts: failed to prepare missed proof outputs statement: %w", err)
+		return fmt.Errorf("failed to prepare missed proof outputs statement: %w", err)
 	}
 	defer missedOutputsStmt.Close()
 
@@ -826,12 +826,12 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
 
 		for i, sco := range fc.ValidProofOutputs {
 			if _, err := validOutputsStmt.Exec(dbID, i, encode(fcID.ValidOutputID(i)), encode(sco.Address), encode(sco.Value)); err != nil {
-				return fmt.Errorf("updateFileContractElements: failed to execute valid proof outputs statement: %w", err)
+				return fmt.Errorf("failed to execute valid proof outputs statement: %w", err)
 			}
 		}
 		for i, sco := range fc.MissedProofOutputs {
 			if _, err := missedOutputsStmt.Exec(dbID, i, encode(fcID.MissedOutputID(i)), encode(sco.Address), encode(sco.Value)); err != nil {
-				return fmt.Errorf("updateFileContractElements: failed to execute missed proof outputs statement: %w", err)
+				return fmt.Errorf("failed to execute missed proof outputs statement: %w", err)
 			}
 		}
 
@@ -906,7 +906,7 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
 			update.Valid,
 			true,
 		); err != nil {
-			return fmt.Errorf("updateFileContractElements: %w", err)
+			return err
 		}
 	}
 
@@ -925,7 +925,7 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
 			}
 
 			if err := addFC(fcID, 0, fc, nil, false, false, false); err != nil {
-				return fmt.Errorf("updateFileContractElements: %w", err)
+				return fmt.Errorf("failed to add contract revised in same block it was created: %w", err)
 			}
 		}
 		// add in any revisions that are not the latest, i.e. contracts that
@@ -938,7 +938,7 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
 			}
 
 			if err := addFC(fcr.ParentID, 0, fc, nil, false, false, false); err != nil {
-				return fmt.Errorf("updateFileContractElements: %w", err)
+				return fmt.Errorf("failed to add earlier revision of contract in same block: %w", err)
 			}
 		}
 	}
@@ -949,7 +949,7 @@ func updateFileContractElements(tx *txn, revert bool, index types.ChainIndex, b 
 func updateFileContractIndices(tx *txn, revert bool, index types.ChainIndex, fces []explorer.FileContractUpdate) error {
 	proofIndexStmt, err := tx.Prepare(`UPDATE last_contract_revision SET proof_height = ?, proof_block_id = ?, proof_transaction_id = ? WHERE contract_id = ?`)
 	if err != nil {
-		return fmt.Errorf("updateFileContractIndices: failed to prepare proof index statement: %w", err)
+		return fmt.Errorf("failed to prepare proof index statement: %w", err)
 	}
 	defer proofIndexStmt.Close()
 
@@ -960,13 +960,13 @@ func updateFileContractIndices(tx *txn, revert bool, index types.ChainIndex, fce
 		if revert {
 			if update.ProofTransactionID != nil {
 				if _, err := proofIndexStmt.Exec(nil, nil, nil, encode(fcID)); err != nil {
-					return fmt.Errorf("updateFileContractIndices: failed to update proof index: %w", err)
+					return fmt.Errorf("failed to update proof index: %w", err)
 				}
 			}
 		} else {
 			if update.ProofTransactionID != nil {
 				if _, err := proofIndexStmt.Exec(encode(index.Height), encode(index.ID), encode(update.ProofTransactionID), encode(fcID)); err != nil {
-					return fmt.Errorf("updateFileContractIndices: failed to update proof index: %w", err)
+					return fmt.Errorf("failed to update proof index: %w", err)
 				}
 			}
 		}
@@ -1008,19 +1008,19 @@ func (ut *updateTx) Metrics(height uint64) (explorer.Metrics, error) {
 
 func (ut *updateTx) ApplyIndex(state explorer.UpdateState) error {
 	if err := addBlock(ut.tx, state.Block, state.ChainIndexElement, state.Metrics.Index.Height); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add block: %w", err)
+		return fmt.Errorf("failed to add block: addBlock: %w", err)
 	} else if err := updateMaturedBalances(ut.tx, false, state.Metrics.Index.Height); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to update matured balances: %w", err)
+		return fmt.Errorf("failed to update matured balances: updateMaturedBalances: %w", err)
 	}
 
 	txnSeen, err := addTransactions(ut.tx, state.Block.ID(), state.Block.Transactions)
 	if err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add transactions: %w", err)
+		return fmt.Errorf("failed to add transactions: addTransactions: %w", err)
 	}
 
 	v2TxnSeen, err := addV2Transactions(ut.tx, state.Block.ID(), state.Block.V2Transactions())
 	if err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add v2 transactions: %w", err)
+		return fmt.Errorf("failed to add v2 transactions: addV2Transactions: %w", err)
 	}
 
 	if err := addSiacoinElements(
@@ -1029,38 +1029,38 @@ func (ut *updateTx) ApplyIndex(state explorer.UpdateState) error {
 		append(state.SpentSiacoinElements, state.EphemeralSiacoinElements...),
 		state.NewSiacoinElements,
 	); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add siacoin outputs: %w", err)
+		return fmt.Errorf("failed to add siacoin outputs: addSiacoinElements: %w", err)
 	} else if err := addSiafundElements(
 		ut.tx,
 		state.Metrics.Index,
 		append(state.SpentSiafundElements, state.EphemeralSiafundElements...),
 		state.NewSiafundElements,
 	); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add siafund outputs: %w", err)
+		return fmt.Errorf("failed to add siafund outputs: addSiafundElements: %w", err)
 	} else if err := updateFileContractElements(ut.tx, false, state.Metrics.Index, state.Block, state.FileContractElements); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add file contracts: %w", err)
+		return fmt.Errorf("failed to add file contracts: updateFileContractElements: %w", err)
 	} else if err := updateV2FileContractElements(ut.tx, false, state.Metrics.Index, state.Block, state.V2FileContractElements); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add v2 file contracts: %w", err)
+		return fmt.Errorf("failed to add v2 file contracts: updateV2FileContractElements: %w", err)
 	} else if err := addTransactionFields(ut.tx, state.Block.Transactions, txnSeen); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add transaction fields: %w", err)
+		return fmt.Errorf("failed to add transaction fields: addTransactionFields: %w", err)
 	} else if err := addV2TransactionFields(ut.tx, state.Block.V2Transactions(), v2TxnSeen); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add v2 transaction fields: %w", err)
+		return fmt.Errorf("failed to add v2 transaction fields: addV2TransactionFields: %w", err)
 	} else if err := updateBalances(ut.tx, state.Metrics.Index.Height, state.SpentSiacoinElements, state.NewSiacoinElements, state.SpentSiafundElements, state.NewSiafundElements); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to update balances: %w", err)
+		return fmt.Errorf("failed to update balances: updateBalances: %w", err)
 	} else if err := addMinerPayouts(ut.tx, state.Block.ID(), state.Block.MinerPayouts); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add miner payouts: %w", err)
+		return fmt.Errorf("failed to add miner payouts: addMinerPayouts: %w", err)
 	} else if err := updateStateTree(ut.tx, state.TreeUpdates); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to update state tree: %w", err)
+		return fmt.Errorf("failed to update state tree: updateStateTree: %w", err)
 	} else if err := addMetrics(ut.tx, state); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to update metrics: %w", err)
+		return fmt.Errorf("failed to update metrics: addMetrics: %w", err)
 	} else if err := addHostAnnouncements(ut.tx, state.Block.Timestamp, state.HostAnnouncements, state.V2HostAnnouncements); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add host announcements: %w", err)
+		return fmt.Errorf("failed to add host announcements: addHostAnnouncements: %w", err)
 	} else if err := updateFileContractIndices(ut.tx, false, state.Metrics.Index, state.FileContractElements); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to update file contract element indices: %w", err)
+		return fmt.Errorf("failed to update file contract element indices: updateFileContractIndices: %w", err)
 	} else if err := updateV2FileContractIndices(ut.tx, false, state.Metrics.Index, state.V2FileContractElements); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to update v2 file contract element indices: %w", err)
+		return fmt.Errorf("failed to update v2 file contract element indices: updateV2FileContractIndices: %w", err)
 	} else if err := addEvents(ut.tx, state.Block.ID(), state.Events); err != nil {
-		return fmt.Errorf("ApplyIndex: failed to add events: %w", err)
+		return fmt.Errorf("failed to add events: addEvents: %w", err)
 	}
 
 	return nil
@@ -1117,13 +1117,13 @@ func (s *Store) AddHostScans(scans ...explorer.HostScan) error {
 	return s.transaction(func(tx *txn) error {
 		unsuccessfulStmt, err := tx.Prepare(`UPDATE host_info SET last_scan = ?, last_scan_successful = 0, last_scan_error = ?, next_scan = ?, total_scans = total_scans + 1, failed_interactions = failed_interactions + 1, failed_interactions_streak = failed_interactions_streak + 1 WHERE public_key = ?`)
 		if err != nil {
-			return fmt.Errorf("addHostScans: failed to prepare unsuccessful statement: %w", err)
+			return fmt.Errorf("failed to prepare unsuccessful statement: %w", err)
 		}
 		defer unsuccessfulStmt.Close()
 
 		successfulStmt, err := tx.Prepare(`UPDATE host_info SET country_code = ?, latitude = ?, longitude = ?, last_scan = ?, last_scan_successful = 1, last_scan_error = "", next_scan = ?, total_scans = total_scans + 1, successful_interactions = successful_interactions + 1, failed_interactions_streak = 0, settings_accepting_contracts = ?, settings_max_download_batch_size = ?, settings_max_duration = ?, settings_max_revise_batch_size = ?, settings_net_address = ?, settings_remaining_storage = ?, settings_sector_size = ?, settings_total_storage = ?, settings_used_storage = ?, settings_address = ?, settings_window_size = ?, settings_collateral = ?, settings_max_collateral = ?, settings_base_rpc_price = ?, settings_contract_price = ?, settings_download_bandwidth_price = ?, settings_sector_access_price = ?, settings_storage_price = ?, settings_upload_bandwidth_price = ?, settings_ephemeral_account_expiry = ?, settings_max_ephemeral_account_balance = ?, settings_revision_number = ?, settings_version = ?, settings_release = ?, settings_sia_mux_port = ?, price_table_uid = ?, price_table_validity = ?, price_table_host_block_height = ?, price_table_update_price_table_cost = ?, price_table_account_balance_cost = ?, price_table_fund_account_cost = ?, price_table_latest_revision_cost = ?, price_table_subscription_memory_cost = ?, price_table_subscription_notification_cost = ?, price_table_init_base_cost = ?, price_table_memory_time_cost = ?, price_table_download_bandwidth_cost = ?, price_table_upload_bandwidth_cost = ?, price_table_drop_sectors_base_cost = ?, price_table_drop_sectors_unit_cost = ?, price_table_has_sector_base_cost = ?, price_table_read_base_cost = ?, price_table_read_length_cost = ?, price_table_renew_contract_cost = ?, price_table_revision_base_cost = ?, price_table_swap_sector_base_cost = ?, price_table_write_base_cost = ?, price_table_write_length_cost = ?, price_table_write_store_cost = ?, price_table_txn_fee_min_recommended = ?, price_table_txn_fee_max_recommended = ?, price_table_contract_price = ?, price_table_collateral_cost = ?, price_table_max_collateral = ?, price_table_max_duration = ?, price_table_window_size = ?, price_table_registry_entries_left = ?, price_table_registry_entries_total = ?, v2_settings_protocol_version = ?, v2_settings_release = ?, v2_settings_wallet_address = ?, v2_settings_accepting_contracts = ?, v2_settings_max_collateral = ?, v2_settings_max_contract_duration = ?, v2_settings_remaining_storage = ?, v2_settings_total_storage = ?, v2_settings_used_storage = ?, v2_prices_contract_price = ?, v2_prices_collateral_price = ?, v2_prices_storage_price = ?, v2_prices_ingress_price = ?, v2_prices_egress_price = ?, v2_prices_free_sector_price = ?, v2_prices_tip_height = ?, v2_prices_valid_until = ?, v2_prices_signature = ? WHERE public_key = ?`)
 		if err != nil {
-			return fmt.Errorf("addHostScans: failed to prepare successful statement: %w", err)
+			return fmt.Errorf("failed to prepare successful statement: %w", err)
 		}
 		defer successfulStmt.Close()
 
@@ -1132,11 +1132,11 @@ func (s *Store) AddHostScans(scans ...explorer.HostScan) error {
 			sV2, pV2 := scan.V2Settings, scan.V2Settings.Prices
 			if scan.Success {
 				if _, err := successfulStmt.Exec(scan.Location.CountryCode, scan.Location.Latitude, scan.Location.Longitude, encode(scan.Timestamp), encode(scan.NextScan), s.AcceptingContracts, encode(s.MaxDownloadBatchSize), encode(s.MaxDuration), encode(s.MaxReviseBatchSize), s.NetAddress, encode(s.RemainingStorage), encode(s.SectorSize), encode(s.TotalStorage), encode(s.TotalStorage-s.RemainingStorage), encode(s.Address), encode(s.WindowSize), encode(s.Collateral), encode(s.MaxCollateral), encode(s.BaseRPCPrice), encode(s.ContractPrice), encode(s.DownloadBandwidthPrice), encode(s.SectorAccessPrice), encode(s.StoragePrice), encode(s.UploadBandwidthPrice), s.EphemeralAccountExpiry, encode(s.MaxEphemeralAccountBalance), encode(s.RevisionNumber), s.Version, s.Release, s.SiaMuxPort, encode(p.UID), p.Validity, encode(p.HostBlockHeight), encode(p.UpdatePriceTableCost), encode(p.AccountBalanceCost), encode(p.FundAccountCost), encode(p.LatestRevisionCost), encode(p.SubscriptionMemoryCost), encode(p.SubscriptionNotificationCost), encode(p.InitBaseCost), encode(p.MemoryTimeCost), encode(p.DownloadBandwidthCost), encode(p.UploadBandwidthCost), encode(p.DropSectorsBaseCost), encode(p.DropSectorsUnitCost), encode(p.HasSectorBaseCost), encode(p.ReadBaseCost), encode(p.ReadLengthCost), encode(p.RenewContractCost), encode(p.RevisionBaseCost), encode(p.SwapSectorBaseCost), encode(p.WriteBaseCost), encode(p.WriteLengthCost), encode(p.WriteStoreCost), encode(p.TxnFeeMinRecommended), encode(p.TxnFeeMaxRecommended), encode(p.ContractPrice), encode(p.CollateralCost), encode(p.MaxCollateral), encode(p.MaxDuration), encode(p.WindowSize), encode(p.RegistryEntriesLeft), encode(p.RegistryEntriesTotal), sV2.ProtocolVersion[:], sV2.Release, encode(sV2.WalletAddress), sV2.AcceptingContracts, encode(sV2.MaxCollateral), encode(sV2.MaxContractDuration), encode(sV2.RemainingStorage), encode(sV2.TotalStorage), encode(sV2.TotalStorage-sV2.RemainingStorage), encode(pV2.ContractPrice), encode(pV2.Collateral), encode(pV2.StoragePrice), encode(pV2.IngressPrice), encode(pV2.EgressPrice), encode(pV2.FreeSectorPrice), encode(pV2.TipHeight), encode(pV2.ValidUntil), encode(pV2.Signature), encode(scan.PublicKey)); err != nil {
-					return fmt.Errorf("addHostScans: failed to execute successful statement: %w", err)
+					return fmt.Errorf("failed to execute successful statement: %w", err)
 				}
 			} else {
 				if _, err := unsuccessfulStmt.Exec(encode(scan.Timestamp), *scan.Error, encode(scan.NextScan), encode(scan.PublicKey)); err != nil {
-					return fmt.Errorf("addHostScans: failed to execute unsuccessful statement: %w", err)
+					return fmt.Errorf("failed to execute unsuccessful statement: %w", err)
 				}
 			}
 		}
@@ -1227,15 +1227,16 @@ func (s *Store) ResetChainState() error {
 	if err := s.transaction(func(tx *txn) error {
 		if _, err := tx.Exec(`PRAGMA defer_foreign_keys=ON`); err != nil {
 			return fmt.Errorf("failed to defer foreign key checks: %w", err)
+		} else if err := resetChainState(tx, s.log, int64(len(migrations)+1)); err != nil {
+			return fmt.Errorf("failed to reset chain state: resetChainState: %w", err)
 		}
-
-		return resetChainState(tx, s.log, int64(len(migrations)+1))
+		return nil
 	}); err != nil {
-		return fmt.Errorf("ResetChainState: failed to delete and reinit database: %w", err)
+		return fmt.Errorf("failed to delete and reinit database: %w", err)
 	}
 
 	if _, err := s.db.Exec(`VACUUM`); err != nil {
-		return fmt.Errorf("ResetChainState: failed to vacuum database: %w", err)
+		return fmt.Errorf("failed to vacuum database: %w", err)
 	}
 
 	return nil

--- a/persist/sqlite/contracts.go
+++ b/persist/sqlite/contracts.go
@@ -57,6 +57,10 @@ func getContracts(tx *txn, ids []types.FileContractID) (result []explorer.Extend
 		}
 		result = append(result, fc)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to retrieve file contract rows: %w", err)
+	}
+
 	return
 }
 
@@ -91,6 +95,9 @@ func (s *Store) ContractRevisions(id types.FileContractID) (revisions []explorer
 			}
 			revisions = append(revisions, fc)
 		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to retrieve file contract rows: %w", err)
+		}
 
 		if len(revisions) == 0 {
 			return explorer.ErrContractNotFound
@@ -119,6 +126,9 @@ func (s *Store) ContractsKey(key types.PublicKey) (result []explorer.ExtendedFil
 				return fmt.Errorf("failed to scan file contract: %w", err)
 			}
 			result = append(result, fc)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to retrieve file contract rows: %w", err)
 		}
 
 		return rows.Err()

--- a/persist/sqlite/hosts.go
+++ b/persist/sqlite/hosts.go
@@ -61,6 +61,9 @@ func (s *Store) HostsForScanning(minLastAnnouncement time.Time, limit uint64) (r
 						}
 						host.V2NetAddresses = append(host.V2NetAddresses, netAddr)
 					}
+					if err := v2AddrRows.Err(); err != nil {
+						return fmt.Errorf("failed to retrieve v2 addr rows: %w", err)
+					}
 					return nil
 				}()
 				if err != nil {
@@ -68,6 +71,9 @@ func (s *Store) HostsForScanning(minLastAnnouncement time.Time, limit uint64) (r
 				}
 			}
 			result = append(result, host)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to retrieve host rows: %w", err)
 		}
 		return nil
 	})
@@ -125,7 +131,7 @@ func (st *Store) QueryHosts(params explorer.HostQuery, sortBy explorer.HostSortC
 					pks = append(pks, encode(pk))
 				}
 				if err := rows.Err(); err != nil {
-					return fmt.Errorf("error retrieving public keys for given net addresses: %w", err)
+					return fmt.Errorf("error retrieving host public keys rows: %w", err)
 				}
 
 				args = append(args, pks...)
@@ -264,6 +270,9 @@ func (st *Store) QueryHosts(params explorer.HostQuery, sortBy explorer.HostSortC
 						}
 						host.V2NetAddresses = append(host.V2NetAddresses, netAddr)
 					}
+					if err := v2AddrRows.Err(); err != nil {
+						return fmt.Errorf("failed to retrieve v2 addr rows: %w", err)
+					}
 				}
 
 				result = append(result, host)
@@ -272,7 +281,10 @@ func (st *Store) QueryHosts(params explorer.HostQuery, sortBy explorer.HostSortC
 				return err
 			}
 		}
-		return rows.Err()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to retrieve host rows: %w", err)
+		}
+		return nil
 	})
 	return
 }

--- a/persist/sqlite/metrics.go
+++ b/persist/sqlite/metrics.go
@@ -144,7 +144,7 @@ func (s *Store) HostMetrics() (result explorer.HostMetrics, err error) {
 			count++
 		}
 		if err := rows.Err(); err != nil {
-			return err
+			return fmt.Errorf("failed to retrieve rows: %w", err)
 		}
 
 		if count > 0 {

--- a/persist/sqlite/metrics.go
+++ b/persist/sqlite/metrics.go
@@ -144,7 +144,7 @@ func (s *Store) HostMetrics() (result explorer.HostMetrics, err error) {
 			count++
 		}
 		if err := rows.Err(); err != nil {
-			return fmt.Errorf("failed to retrieve rows: %w", err)
+			return fmt.Errorf("failed to retrieve host rows: %w", err)
 		}
 
 		if count > 0 {

--- a/persist/sqlite/revert.go
+++ b/persist/sqlite/revert.go
@@ -244,46 +244,46 @@ func deleteBlock(tx *txn, bid types.BlockID) error {
 
 func (ut *updateTx) RevertIndex(state explorer.UpdateState) error {
 	if err := updateMaturedBalances(ut.tx, true, state.Metrics.Index.Height); err != nil {
-		return fmt.Errorf("failed to update matured balances: updateMaturedBalances: %w", err)
+		return fmt.Errorf("failed to update matured balances: %w", err)
 	} else if err := addSiacoinElements(
 		ut.tx,
 		state.Metrics.Index,
 		state.SpentSiacoinElements,
 		append(state.NewSiacoinElements, state.EphemeralSiacoinElements...),
 	); err != nil {
-		return fmt.Errorf("failed to update siacoin output state: addSiacoinElements: %w", err)
+		return fmt.Errorf("failed to update siacoin output state: %w", err)
 	} else if err := addSiafundElements(
 		ut.tx,
 		state.Metrics.Index,
 		state.SpentSiafundElements,
 		append(state.NewSiafundElements, state.EphemeralSiafundElements...),
 	); err != nil {
-		return fmt.Errorf("failed to update siafund output state: addSiafundElements: %w", err)
+		return fmt.Errorf("failed to update siafund output state: %w", err)
 	} else if err := updateBalances(ut.tx, state.Metrics.Index.Height, state.SpentSiacoinElements, state.NewSiacoinElements, state.SpentSiafundElements, state.NewSiafundElements); err != nil {
-		return fmt.Errorf("failed to update balances: updateBalances: %w", err)
+		return fmt.Errorf("failed to update balances: %w", err)
 	} else if err := updateFileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.FileContractElements); err != nil {
-		return fmt.Errorf("failed to update file contract state: updateFileContractElements: %w", err)
+		return fmt.Errorf("failed to update file contract state: %w", err)
 	} else if err := updateV2FileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.V2FileContractElements); err != nil {
-		return fmt.Errorf("failed to add v2 file contracts: updateV2FileContractElements: %w", err)
+		return fmt.Errorf("failed to add v2 file contracts: %w", err)
 	} else if err := updateFileContractIndices(ut.tx, true, state.Metrics.Index, state.FileContractElements); err != nil {
-		return fmt.Errorf("failed to update file contract element indices: updateFileContractIndices: %w", err)
+		return fmt.Errorf("failed to update file contract element indices: %w", err)
 	} else if err := updateV2FileContractIndices(ut.tx, true, state.Metrics.Index, state.V2FileContractElements); err != nil {
-		return fmt.Errorf("failed to update v2 file contract element indices: updateV2FileContractIndices: %w", err)
+		return fmt.Errorf("failed to update v2 file contract element indices: %w", err)
 	} else if err := updateStateTree(ut.tx, state.TreeUpdates); err != nil {
-		return fmt.Errorf("failed to update state tree: updateStateTree: %w", err)
+		return fmt.Errorf("failed to update state tree: %w", err)
 	}
 
 	bid := state.Block.ID()
 	if err := deleteEvents(ut.tx, bid); err != nil {
-		return fmt.Errorf("failed to delete events: deleteEvents: %w", err)
+		return fmt.Errorf("failed to delete events: %w", err)
 	} else if err := deleteLastContractRevisions(ut.tx, bid); err != nil {
-		return fmt.Errorf("failed to delete from block transactions tables: deleteLastContractRevisions: %w", err)
+		return fmt.Errorf("failed to delete from block transactions tables: %w", err)
 	} else if err := deleteV1Transactions(ut.tx, bid); err != nil {
-		return fmt.Errorf("failed to delete v1 transactions: deleteV1Transactions: %w", err)
+		return fmt.Errorf("failed to delete v1 transactions: %w", err)
 	} else if err := deleteV2Transactions(ut.tx, bid); err != nil {
-		return fmt.Errorf("failed to delete v2 transactions: deleteV2Transactions: %w", err)
+		return fmt.Errorf("failed to delete v2 transactions: %w", err)
 	} else if err := deleteBlock(ut.tx, bid); err != nil {
-		return fmt.Errorf("failed to delete block: deleteBlock: %w", err)
+		return fmt.Errorf("failed to delete block: %w", err)
 	}
 
 	return nil

--- a/persist/sqlite/revert.go
+++ b/persist/sqlite/revert.go
@@ -244,46 +244,46 @@ func deleteBlock(tx *txn, bid types.BlockID) error {
 
 func (ut *updateTx) RevertIndex(state explorer.UpdateState) error {
 	if err := updateMaturedBalances(ut.tx, true, state.Metrics.Index.Height); err != nil {
-		return fmt.Errorf("RevertIndex: failed to update matured balances: %w", err)
+		return fmt.Errorf("failed to update matured balances: updateMaturedBalances: %w", err)
 	} else if err := addSiacoinElements(
 		ut.tx,
 		state.Metrics.Index,
 		state.SpentSiacoinElements,
 		append(state.NewSiacoinElements, state.EphemeralSiacoinElements...),
 	); err != nil {
-		return fmt.Errorf("RevertIndex: failed to update siacoin output state: %w", err)
+		return fmt.Errorf("failed to update siacoin output state: addSiacoinElements: %w", err)
 	} else if err := addSiafundElements(
 		ut.tx,
 		state.Metrics.Index,
 		state.SpentSiafundElements,
 		append(state.NewSiafundElements, state.EphemeralSiafundElements...),
 	); err != nil {
-		return fmt.Errorf("RevertIndex: failed to update siafund output state: %w", err)
+		return fmt.Errorf("failed to update siafund output state: addSiafundElements: %w", err)
 	} else if err := updateBalances(ut.tx, state.Metrics.Index.Height, state.SpentSiacoinElements, state.NewSiacoinElements, state.SpentSiafundElements, state.NewSiafundElements); err != nil {
-		return fmt.Errorf("RevertIndex: failed to update balances: %w", err)
+		return fmt.Errorf("failed to update balances: updateBalances: %w", err)
 	} else if err := updateFileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.FileContractElements); err != nil {
-		return fmt.Errorf("RevertIndex: failed to update file contract state: %w", err)
+		return fmt.Errorf("failed to update file contract state: updateFileContractElements: %w", err)
 	} else if err := updateV2FileContractElements(ut.tx, true, state.Metrics.Index, state.Block, state.V2FileContractElements); err != nil {
-		return fmt.Errorf("RevertIndex: failed to add v2 file contracts: %w", err)
+		return fmt.Errorf("failed to add v2 file contracts: updateV2FileContractElements: %w", err)
 	} else if err := updateFileContractIndices(ut.tx, true, state.Metrics.Index, state.FileContractElements); err != nil {
-		return fmt.Errorf("RevertIndex: failed to update file contract element indices: %w", err)
+		return fmt.Errorf("failed to update file contract element indices: updateFileContractIndices: %w", err)
 	} else if err := updateV2FileContractIndices(ut.tx, true, state.Metrics.Index, state.V2FileContractElements); err != nil {
-		return fmt.Errorf("RevertIndex: failed to update v2 file contract element indices: %w", err)
+		return fmt.Errorf("failed to update v2 file contract element indices: updateV2FileContractIndices: %w", err)
 	} else if err := updateStateTree(ut.tx, state.TreeUpdates); err != nil {
-		return fmt.Errorf("RevertIndex: failed to update state tree: %w", err)
+		return fmt.Errorf("failed to update state tree: updateStateTree: %w", err)
 	}
 
 	bid := state.Block.ID()
 	if err := deleteEvents(ut.tx, bid); err != nil {
-		return fmt.Errorf("RevertIndex: failed to delete events: %w", err)
+		return fmt.Errorf("failed to delete events: deleteEvents: %w", err)
 	} else if err := deleteLastContractRevisions(ut.tx, bid); err != nil {
-		return fmt.Errorf("RevertIndex: failed to delete from block transactions tables: %w", err)
+		return fmt.Errorf("failed to delete from block transactions tables: deleteLastContractRevisions: %w", err)
 	} else if err := deleteV1Transactions(ut.tx, bid); err != nil {
-		return fmt.Errorf("RevertIndex: failed to delete v1 transactions: %w", err)
+		return fmt.Errorf("failed to delete v1 transactions: deleteV1Transactions: %w", err)
 	} else if err := deleteV2Transactions(ut.tx, bid); err != nil {
-		return fmt.Errorf("RevertIndex: failed to delete v2 transactions: %w", err)
+		return fmt.Errorf("failed to delete v2 transactions: deleteV2Transactions: %w", err)
 	} else if err := deleteBlock(ut.tx, bid); err != nil {
-		return fmt.Errorf("RevertIndex: failed to delete block: %w", err)
+		return fmt.Errorf("failed to delete block: deleteBlock: %w", err)
 	}
 
 	return nil

--- a/persist/sqlite/search.go
+++ b/persist/sqlite/search.go
@@ -55,7 +55,7 @@ func (s *Store) Search(input string) (explorer.SearchType, error) {
 		for _, q := range queries {
 			err := tx.QueryRow(q.query, id).Scan(&exists)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to query %v: %w", q.typ, err)
 			}
 			if exists {
 				result = q.typ

--- a/persist/sqlite/transactions.go
+++ b/persist/sqlite/transactions.go
@@ -33,7 +33,10 @@ LIMIT ? OFFSET ?`, encode(txnID), limit, offset)
 			}
 			indices = append(indices, index)
 		}
-		return rows.Err()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to retrieve chain index rows: %w", err)
+		}
+		return nil
 	})
 	return
 }
@@ -64,7 +67,10 @@ ORDER BY transaction_order ASC`)
 				}
 				txns[i].MinerFees = append(txns[i].MinerFees, fee)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve miner fee rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -99,7 +105,10 @@ ORDER BY transaction_order ASC`)
 				}
 				txns[i].ArbitraryData = append(txns[i].ArbitraryData, data)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve arbitrary data rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -134,7 +143,10 @@ ORDER BY transaction_order ASC`)
 				}
 				txns[i].Signatures = append(txns[i].Signatures, sig)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve signature rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -174,7 +186,10 @@ ORDER BY ts.transaction_order ASC`)
 				}
 				txns[i].SiacoinOutputs = append(txns[i].SiacoinOutputs, sco)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve siacoin output rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -211,7 +226,10 @@ ORDER BY ts.transaction_order ASC`)
 				sci.Address = sci.UnlockConditions.UnlockHash()
 				txns[i].SiacoinInputs = append(txns[i].SiacoinInputs, sci)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve siacoin input rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -248,7 +266,10 @@ ORDER BY ts.transaction_order ASC`)
 				sfi.Address = sfi.UnlockConditions.UnlockHash()
 				txns[i].SiafundInputs = append(txns[i].SiafundInputs, sfi)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve siafund input rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -289,7 +310,10 @@ ORDER BY ts.transaction_order ASC`)
 				}
 				txns[i].SiafundOutputs = append(txns[i].SiafundOutputs, sfo)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve siafund output rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -315,6 +339,9 @@ func fileContractOutputs(tx *txn, contractID int64) (valid []explorer.ContractSi
 		}
 		valid = append(valid, sco)
 	}
+	if err := validRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("failed to get valid contract rows: %w", err)
+	}
 
 	missedRows, err := tx.Query(`SELECT id, address, value
 FROM file_contract_missed_proof_outputs
@@ -332,6 +359,10 @@ ORDER BY contract_order ASC`, contractID)
 		}
 		missed = append(missed, sco)
 	}
+	if err := missedRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("failed to get missed contract rows: %w", err)
+	}
+
 	return valid, missed, nil
 }
 
@@ -363,7 +394,10 @@ ORDER BY ts.transaction_order ASC`)
 				}
 				txns[i].FileContracts = append(txns[i].FileContracts, fc)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve file contract rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -416,7 +450,10 @@ ORDER BY ts.transaction_order ASC`)
 
 				txns[i].FileContractRevisions = append(txns[i].FileContractRevisions, fc)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve file contract revision rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -453,7 +490,10 @@ ORDER BY transaction_order ASC`)
 				proof.Leaf = [64]byte(leaf)
 				txns[i].StorageProofs = append(txns[i].StorageProofs, proof)
 			}
-			return rows.Err()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve storage proof rows: %w", err)
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -486,6 +526,9 @@ WHERE block_id = ? ORDER BY block_order ASC`, encode(blockID))
 		}
 		txnIDs = append(txnIDs, txnID)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed retrieve block transaction ID rows: %w", err)
+	}
 
 	return
 }
@@ -515,7 +558,10 @@ ORDER BY mp.block_order ASC`
 		}
 		result = append(result, output)
 	}
-	return result, nil
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to retrieve miner payout rows: %w", err)
+	}
+	return result, rows.Err()
 }
 
 // transactionDatabaseIDs returns the database ID for each transaction.

--- a/persist/sqlite/transactions.go
+++ b/persist/sqlite/transactions.go
@@ -22,7 +22,7 @@ WHERE t.transaction_id = ?
 ORDER BY b.height DESC
 LIMIT ? OFFSET ?`, encode(txnID), limit, offset)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to query chain indices: %w", err)
 		}
 		defer rows.Close()
 
@@ -475,7 +475,7 @@ FROM block_transactions bt
 INNER JOIN transactions t ON t.id = bt.transaction_id
 WHERE block_id = ? ORDER BY block_order ASC`, encode(blockID))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to query block transaction IDs: %w", err)
 	}
 	defer rows.Close()
 
@@ -545,27 +545,27 @@ func transactionDatabaseIDs(tx *txn, txnIDs []types.TransactionID) (dbIDs []int6
 func getTransactions(tx *txn, ids []types.TransactionID) ([]explorer.Transaction, error) {
 	dbIDs, txns, err := transactionDatabaseIDs(tx, ids)
 	if err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get base transactions: %w", err)
+		return nil, fmt.Errorf("failed to get base transactions: %w", err)
 	} else if err := decorateArbitraryData(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get arbitrary data: %w", err)
+		return nil, fmt.Errorf("failed to get arbitrary data: %w", err)
 	} else if err := decorateMinerFees(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get miner fees: %w", err)
+		return nil, fmt.Errorf("failed to get miner fees: %w", err)
 	} else if err := decorateSignatures(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get signatures: %w", err)
+		return nil, fmt.Errorf("failed to get signatures: %w", err)
 	} else if err := decorateSiacoinInputs(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get siacoin inputs: %w", err)
+		return nil, fmt.Errorf("failed to get siacoin inputs: %w", err)
 	} else if err := decorateSiacoinOutputs(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get siacoin outputs: %w", err)
+		return nil, fmt.Errorf("failed to get siacoin outputs: %w", err)
 	} else if err := decorateSiafundInputs(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get siafund inputs: %w", err)
+		return nil, fmt.Errorf("failed to get siafund inputs: %w", err)
 	} else if err := decorateSiafundOutputs(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get siafund outputs: %w", err)
+		return nil, fmt.Errorf("failed to get siafund outputs: %w", err)
 	} else if err := decorateFileContracts(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get file contracts: %w", err)
+		return nil, fmt.Errorf("failed to get file contracts: %w", err)
 	} else if err := decorateFileContractRevisions(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get file contract revisions: %w", err)
+		return nil, fmt.Errorf("failed to get file contract revisions: %w", err)
 	} else if err := decorateStorageProofs(tx, dbIDs, txns); err != nil {
-		return nil, fmt.Errorf("getTransactions: failed to get storage proofs: %w", err)
+		return nil, fmt.Errorf("failed to get storage proofs: %w", err)
 	}
 
 	for i := range txns {

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -76,7 +76,7 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
         DO UPDATE SET leaf_index = ?
         RETURNING id;`)
 	if err != nil {
-		return fmt.Errorf("updateV2FileContractElements: failed to prepare main statement: %w", err)
+		return fmt.Errorf("failed to prepare main statement: %w", err)
 	}
 	defer stmt.Close()
 
@@ -85,14 +85,14 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
     ON CONFLICT (contract_id)
     DO UPDATE SET contract_element_id = ?, confirmation_height = COALESCE(?, confirmation_height), confirmation_block_id = COALESCE(?, confirmation_block_id), confirmation_transaction_id = COALESCE(?, confirmation_transaction_id)`)
 	if err != nil {
-		return fmt.Errorf("updateV2FileContractElements: failed to prepare last_contract_revision statement: %w", err)
+		return fmt.Errorf("failed to prepare last_contract_revision statement: %w", err)
 	}
 	defer revisionStmt.Close()
 
 	// so we can get the ids of revision parents to add to the DB
 	parentStmt, err := tx.Prepare(`SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?`)
 	if err != nil {
-		return fmt.Errorf("updateV2FileContractElements: failed to prepare parent statement: %w", err)
+		return fmt.Errorf("failed to prepare parent statement: %w", err)
 	}
 	defer parentStmt.Close()
 
@@ -186,7 +186,7 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 			update.ConfirmationTransactionID,
 			true,
 		); err != nil {
-			return fmt.Errorf("updateV2FileContractElements: %w", err)
+			return fmt.Errorf("failed to update contract: %w", err)
 		}
 	}
 
@@ -219,7 +219,7 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 			}
 
 			if err := addFC(fcID, 0, fc, nil, false); err != nil {
-				return fmt.Errorf("updateV2FileContractElements: %w", err)
+				return fmt.Errorf("failed to add earlier revision of contract in same block: %w", err)
 			}
 		}
 		// Add the new renewal contracts
@@ -238,7 +238,7 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 					}
 
 					if err := addFC(fcID, 0, fc, nil, false); err != nil {
-						return fmt.Errorf("updateV2FileContractElements: failed to add new contract: %w", err)
+						return fmt.Errorf("failed to add initial new renewal contract: %w", err)
 					}
 				}
 			}
@@ -251,13 +251,13 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 func updateV2FileContractIndices(tx *txn, revert bool, index types.ChainIndex, fces []explorer.V2FileContractUpdate) error {
 	resolutionIndexStmt, err := tx.Prepare(`UPDATE v2_last_contract_revision SET resolution_type = ?, resolution_height = ?, resolution_block_id = ?, resolution_transaction_id = ?, renewed_to = ? WHERE contract_id = ?`)
 	if err != nil {
-		return fmt.Errorf("updateV2FileContractIndices: failed to prepare resolution index statement: %w", err)
+		return fmt.Errorf("failed to prepare resolution index statement: %w", err)
 	}
 	defer resolutionIndexStmt.Close()
 
 	renewedFromStmt, err := tx.Prepare(`UPDATE v2_last_contract_revision SET renewed_from = ? WHERE contract_id = ?`)
 	if err != nil {
-		return fmt.Errorf("updateV2FileContractIndices: failed to prepare renewed from statement: %w", err)
+		return fmt.Errorf("failed to prepare renewed from statement: %w", err)
 	}
 	defer renewedFromStmt.Close()
 
@@ -268,7 +268,7 @@ func updateV2FileContractIndices(tx *txn, revert bool, index types.ChainIndex, f
 		if revert {
 			if update.ResolutionTransactionID != nil {
 				if _, err := resolutionIndexStmt.Exec(explorer.V2ResolutionInvalid, nil, nil, nil, nil, encode(fcID)); err != nil {
-					return fmt.Errorf("updateV2FileContractIndices: failed to update resolution index: %w", err)
+					return fmt.Errorf("failed to update resolution index: %w", err)
 				}
 			}
 		} else {
@@ -280,11 +280,11 @@ func updateV2FileContractIndices(tx *txn, revert bool, index types.ChainIndex, f
 
 				resolutionType := explorer.V2ResolutionType(update.Resolution)
 				if _, err := resolutionIndexStmt.Exec(resolutionType, encode(index.Height), encode(index.ID), encode(update.ResolutionTransactionID), renewalToID, encode(fcID)); err != nil {
-					return fmt.Errorf("updateV2FileContractIndices: failed to update resolution index: %w", err)
+					return fmt.Errorf("failed to update resolution index: %w", err)
 				}
 				if renewalToID != nil {
 					if _, err := renewedFromStmt.Exec(encode(fcID), renewalToID); err != nil {
-						return fmt.Errorf("updateV2FileContractIndices: failed to update renewed from ID: %w", err)
+						return fmt.Errorf("failed to update renewed from ID: %w", err)
 					}
 				}
 			}
@@ -301,13 +301,13 @@ func addV2SiacoinInputs(tx *txn, dbID int64, siacoinInputs []types.V2SiacoinInpu
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siacoin_inputs(transaction_id, transaction_order, satisfied_policy, parent_id) VALUES (?, ?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
 	if err != nil {
-		return fmt.Errorf("addV2SiacoinInputs: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, sci := range siacoinInputs {
 		if _, err := stmt.Exec(dbID, i, encode(sci.SatisfiedPolicy), encode(types.SiacoinOutputID(sci.Parent.ID))); err != nil {
-			return fmt.Errorf("addV2SiacoinInputs: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -320,13 +320,13 @@ func addV2SiacoinOutputs(tx *txn, dbID int64, txnID types.TransactionID, txn typ
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siacoin_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?))`)
 	if err != nil {
-		return fmt.Errorf("addV2SiacoinOutputs: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i := range txn.SiacoinOutputs {
 		if _, err := stmt.Exec(dbID, i, encode(txn.SiacoinOutputID(txnID, i))); err != nil {
-			return fmt.Errorf("addV2SiacoinOutputs: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -339,13 +339,13 @@ func addV2SiafundInputs(tx *txn, dbID int64, siafundInputs []types.V2SiafundInpu
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siafund_inputs(transaction_id, transaction_order, claim_address, satisfied_policy, parent_id) VALUES (?, ?, ?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
 	if err != nil {
-		return fmt.Errorf("addV2SiafundInputs: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, sfi := range siafundInputs {
 		if _, err := stmt.Exec(dbID, i, encode(sfi.ClaimAddress), encode(sfi.SatisfiedPolicy), encode(types.SiafundOutputID(sfi.Parent.ID))); err != nil {
-			return fmt.Errorf("addV2SiafundInputs: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -358,13 +358,13 @@ func addV2SiafundOutputs(tx *txn, dbID int64, txnID types.TransactionID, txn typ
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_siafund_outputs(transaction_id, transaction_order, output_id) VALUES (?, ?, (SELECT id FROM siafund_elements WHERE output_id = ?))`)
 	if err != nil {
-		return fmt.Errorf("addV2SiafundOutputs: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i := range txn.SiafundOutputs {
 		if _, err := stmt.Exec(dbID, i, encode(txn.SiafundOutputID(txnID, i))); err != nil {
-			return fmt.Errorf("addV2SiafundOutputs: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -396,13 +396,13 @@ func addV2FileContractRevisions(tx *txn, dbID int64, fileContractRevisions []typ
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_revisions(transaction_id, transaction_order, parent_contract_id, revision_contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
-		return fmt.Errorf("addV2FileContractRevisions: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, fcr := range fileContractRevisions {
 		if _, err := stmt.Exec(dbID, i, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Revision.RevisionNumber)); err != nil {
-			return fmt.Errorf("addV2FileContractRevisions: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -415,19 +415,19 @@ func addV2FileContractResolutions(tx *txn, dbID int64, fileContractResolutions [
 
 	renewalStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, resolution_type, renewal_final_renter_output_address, renewal_final_renter_output_value, renewal_final_host_output_address, renewal_final_host_output_value, renewal_renter_rollover, renewal_host_rollover, renewal_renter_signature, renewal_host_signature, parent_contract_id, renewal_new_contract_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?), (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
-		return fmt.Errorf("addV2FileContractResolutions: failed to prepare renewal statement: %w", err)
+		return fmt.Errorf("failed to prepare renewal statement: %w", err)
 	}
 	defer renewalStmt.Close()
 
 	storageProofStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, resolution_type, storage_proof_proof_index, storage_proof_leaf, storage_proof_proof, parent_contract_id) VALUES (?, ?, ?, ?, ?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
-		return fmt.Errorf("addV2FileContractResolutions: failed to prepare storage proof statement: %w", err)
+		return fmt.Errorf("failed to prepare storage proof statement: %w", err)
 	}
 	defer storageProofStmt.Close()
 
 	expirationStmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contract_resolutions(transaction_id, transaction_order, resolution_type, parent_contract_id) VALUES (?, ?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
-		return fmt.Errorf("addV2FileContractResolutions: failed to prepare expiration statement: %w", err)
+		return fmt.Errorf("failed to prepare expiration statement: %w", err)
 	}
 	defer expirationStmt.Close()
 
@@ -436,15 +436,15 @@ func addV2FileContractResolutions(tx *txn, dbID int64, fileContractResolutions [
 		switch v := fcr.Resolution.(type) {
 		case *types.V2FileContractRenewal:
 			if _, err := renewalStmt.Exec(dbID, i, resolutionType, encode(v.FinalRenterOutput.Address), encode(v.FinalRenterOutput.Value), encode(v.FinalHostOutput.Address), encode(v.FinalHostOutput.Value), encode(v.RenterRollover), encode(v.HostRollover), encode(v.RenterSignature), encode(v.HostSignature), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber), encode(types.FileContractID(fcr.Parent.ID).V2RenewalID()), encode(v.NewContract.RevisionNumber)); err != nil {
-				return fmt.Errorf("addV2FileContractResolutions: failed to execute renewal statement: %w", err)
+				return fmt.Errorf("failed to execute renewal statement: %w", err)
 			}
 		case *types.V2StorageProof:
 			if _, err := storageProofStmt.Exec(dbID, i, resolutionType, encode(v.ProofIndex), v.Leaf[:], encode(v.Proof), encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber)); err != nil {
-				return fmt.Errorf("addV2FileContractResolutions: failed to execute storage proof statement: %w", err)
+				return fmt.Errorf("failed to execute storage proof statement: %w", err)
 			}
 		case *types.V2FileContractExpiration:
 			if _, err := expirationStmt.Exec(dbID, i, resolutionType, encode(types.FileContractID(fcr.Parent.ID)), encode(fcr.Parent.V2FileContract.RevisionNumber)); err != nil {
-				return fmt.Errorf("addV2FileContractResolutions: failed to execute expiration statement: %w", err)
+				return fmt.Errorf("failed to execute expiration statement: %w", err)
 			}
 		}
 	}
@@ -458,13 +458,13 @@ func addV2Attestations(tx *txn, dbID int64, attestations []types.Attestation) er
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_attestations(transaction_id, transaction_order, public_key, key, value, signature) VALUES (?, ?, ?, ?, ?, ?)`)
 	if err != nil {
-		return fmt.Errorf("addV2Attestations: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, attestation := range attestations {
 		if _, err := stmt.Exec(dbID, i, encode(attestation.PublicKey), attestation.Key, attestation.Value, encode(attestation.Signature)); err != nil {
-			return fmt.Errorf("addV2Attestations: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil
@@ -497,21 +497,21 @@ func addV2TransactionFields(tx *txn, txns []types.V2Transaction, txnSeen map[typ
 		}
 
 		if err := addV2Attestations(tx, dbID, txn.Attestations); err != nil {
-			return fmt.Errorf("failed to add attestations: %w", err)
+			return fmt.Errorf("failed to add attestations: addV2Attestations: %w", err)
 		} else if err := addV2SiacoinInputs(tx, dbID, txn.SiacoinInputs); err != nil {
-			return fmt.Errorf("failed to add siacoin inputs: %w", err)
+			return fmt.Errorf("failed to add siacoin inputs: addV2SiacoinInputs: %w", err)
 		} else if err := addV2SiacoinOutputs(tx, dbID, txnID, txn); err != nil {
-			return fmt.Errorf("failed to add siacoin outputs: %w", err)
+			return fmt.Errorf("failed to add siacoin outputs: addV2SiacoinOutputs: %w", err)
 		} else if err := addV2SiafundInputs(tx, dbID, txn.SiafundInputs); err != nil {
-			return fmt.Errorf("failed to add siafund inputs: %w", err)
+			return fmt.Errorf("failed to add siafund inputs: addV2SiafundInputs: %w", err)
 		} else if err := addV2SiafundOutputs(tx, dbID, txnID, txn); err != nil {
-			return fmt.Errorf("failed to add siafund outputs: %w", err)
+			return fmt.Errorf("failed to add siafund outputs: addV2SiafundOutputs: %w", err)
 		} else if err := addV2FileContracts(tx, dbID, txnID, txn); err != nil {
-			return fmt.Errorf("failed to add file contracts: %w", err)
+			return fmt.Errorf("failed to add file contracts: addV2FileContracts: %w", err)
 		} else if err := addV2FileContractRevisions(tx, dbID, txn.FileContractRevisions); err != nil {
-			return fmt.Errorf("failed to add file contract revisions: %w", err)
+			return fmt.Errorf("failed to add file contract revisions: addV2FileContractRevisions: %w", err)
 		} else if err := addV2FileContractResolutions(tx, dbID, txn.FileContractResolutions); err != nil {
-			return fmt.Errorf("failed to add file contract resolutions: %w", err)
+			return fmt.Errorf("failed to add file contract resolutions: addV2FileContractResolutions: %w", err)
 		}
 	}
 

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -205,7 +205,7 @@ func updateV2FileContractElements(tx *txn, revert bool, index types.ChainIndex, 
 			}
 
 			if err := addFC(fcID, 0, fc, nil, false); err != nil {
-				return fmt.Errorf("updateV2FileContractElements: %w", err)
+				return fmt.Errorf("failed to add contract revised in same block it was created: %w", err)
 			}
 		}
 		// add in any revisions that are not the latest, i.e. contracts that
@@ -377,13 +377,13 @@ func addV2FileContracts(tx *txn, dbID int64, txnID types.TransactionID, txn type
 
 	stmt, err := tx.Prepare(`INSERT INTO v2_transaction_file_contracts(transaction_id, transaction_order, contract_id) VALUES (?, ?, (SELECT id FROM v2_file_contract_elements WHERE contract_id = ? AND revision_number = ?))`)
 	if err != nil {
-		return fmt.Errorf("addV2FileContracts: failed to prepare statement: %w", err)
+		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for i, fc := range txn.FileContracts {
 		if _, err := stmt.Exec(dbID, i, encode(txn.V2FileContractID(txnID, i)), encode(fc.RevisionNumber)); err != nil {
-			return fmt.Errorf("addV2FileContracts: failed to execute statement: %w", err)
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 	}
 	return nil

--- a/persist/sqlite/v2consensus.go
+++ b/persist/sqlite/v2consensus.go
@@ -497,21 +497,21 @@ func addV2TransactionFields(tx *txn, txns []types.V2Transaction, txnSeen map[typ
 		}
 
 		if err := addV2Attestations(tx, dbID, txn.Attestations); err != nil {
-			return fmt.Errorf("failed to add attestations: addV2Attestations: %w", err)
+			return fmt.Errorf("failed to add attestations: %w", err)
 		} else if err := addV2SiacoinInputs(tx, dbID, txn.SiacoinInputs); err != nil {
-			return fmt.Errorf("failed to add siacoin inputs: addV2SiacoinInputs: %w", err)
+			return fmt.Errorf("failed to add siacoin inputs: %w", err)
 		} else if err := addV2SiacoinOutputs(tx, dbID, txnID, txn); err != nil {
-			return fmt.Errorf("failed to add siacoin outputs: addV2SiacoinOutputs: %w", err)
+			return fmt.Errorf("failed to add siacoin outputs: %w", err)
 		} else if err := addV2SiafundInputs(tx, dbID, txn.SiafundInputs); err != nil {
-			return fmt.Errorf("failed to add siafund inputs: addV2SiafundInputs: %w", err)
+			return fmt.Errorf("failed to add siafund inputs: %w", err)
 		} else if err := addV2SiafundOutputs(tx, dbID, txnID, txn); err != nil {
-			return fmt.Errorf("failed to add siafund outputs: addV2SiafundOutputs: %w", err)
+			return fmt.Errorf("failed to add siafund outputs: %w", err)
 		} else if err := addV2FileContracts(tx, dbID, txnID, txn); err != nil {
-			return fmt.Errorf("failed to add file contracts: addV2FileContracts: %w", err)
+			return fmt.Errorf("failed to add file contracts: %w", err)
 		} else if err := addV2FileContractRevisions(tx, dbID, txn.FileContractRevisions); err != nil {
-			return fmt.Errorf("failed to add file contract revisions: addV2FileContractRevisions: %w", err)
+			return fmt.Errorf("failed to add file contract revisions: %w", err)
 		} else if err := addV2FileContractResolutions(tx, dbID, txn.FileContractResolutions); err != nil {
-			return fmt.Errorf("failed to add file contract resolutions: addV2FileContractResolutions: %w", err)
+			return fmt.Errorf("failed to add file contract resolutions: %w", err)
 		}
 	}
 

--- a/persist/sqlite/v2contracts.go
+++ b/persist/sqlite/v2contracts.go
@@ -48,7 +48,7 @@ INNER JOIN v2_file_contract_elements fc ON rev.contract_element_id = fc.id
 WHERE rev.contract_id = ?
 `)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to query file contracts: %w", err)
 		}
 		defer stmt.Close()
 
@@ -88,14 +88,14 @@ ORDER BY fc.revision_number ASC
 `
 		rows, err := tx.Query(query, encode(id))
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to query file contract revisions: %w", err)
 		}
 		defer rows.Close()
 
 		for rows.Next() {
 			fc, err := scanV2FileContract(rows)
 			if err != nil {
-				return fmt.Errorf("failed to scan file contract: %w", err)
+				return fmt.Errorf("failed to scan file contract revision: %w", err)
 			}
 
 			revisions = append(revisions, fc)
@@ -120,7 +120,7 @@ WHERE fc.renter_public_key = ? OR fc.host_public_key = ?
 ORDER BY rev.confirmation_height ASC
 `, encoded, encoded)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to query file contracts using given pubkey: %w", err)
 		}
 		defer rows.Close()
 

--- a/persist/sqlite/v2contracts.go
+++ b/persist/sqlite/v2contracts.go
@@ -100,6 +100,9 @@ ORDER BY fc.revision_number ASC
 
 			revisions = append(revisions, fc)
 		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to retrieve file contract rows: %w", err)
+		}
 
 		if len(revisions) == 0 {
 			return explorer.ErrContractNotFound
@@ -130,6 +133,9 @@ ORDER BY rev.confirmation_height ASC
 				return fmt.Errorf("failed to scan file contract: %w", err)
 			}
 			result = append(result, fc)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to retrieve file contract rows: %w", err)
 		}
 
 		return nil

--- a/persist/sqlite/v2transactions.go
+++ b/persist/sqlite/v2transactions.go
@@ -33,7 +33,10 @@ LIMIT ? OFFSET ?`, encode(txnID), limit, offset)
 			}
 			indices = append(indices, index)
 		}
-		return rows.Err()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to retrieve chain index rows: %w", err)
+		}
+		return nil
 	})
 	return
 }
@@ -56,6 +59,9 @@ WHERE block_id = ? ORDER BY block_order ASC`, encode(blockID))
 			return nil, fmt.Errorf("failed to scan block transaction: %w", err)
 		}
 		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to retrieve chain index rows: %w", err)
 	}
 	return
 }
@@ -153,6 +159,9 @@ func decorateV2Attestations(tx *txn, dbIDs []int64, txns []explorer.V2Transactio
 				}
 				txns[i].Attestations = append(txns[i].Attestations, attestation)
 			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve attestation rows: %w", err)
+			}
 			return nil
 		}()
 		if err != nil {
@@ -190,6 +199,9 @@ ORDER BY ts.transaction_order ASC`)
 				}
 
 				txns[i].SiacoinInputs = append(txns[i].SiacoinInputs, sci)
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve siacoin input rows: %w", err)
 			}
 			return nil
 		}()
@@ -233,6 +245,9 @@ ORDER BY ts.transaction_order ASC`)
 				}
 				txns[i].SiacoinOutputs = append(txns[i].SiacoinOutputs, sco)
 			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve siacoin output rows: %w", err)
+			}
 			return nil
 		}()
 		if err != nil {
@@ -270,6 +285,9 @@ ORDER BY ts.transaction_order ASC`)
 				}
 
 				txns[i].SiafundInputs = append(txns[i].SiafundInputs, sfi)
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve siafund input rows: %w", err)
 			}
 			return nil
 		}()
@@ -313,6 +331,9 @@ ORDER BY ts.transaction_order ASC`)
 
 				txns[i].SiafundOutputs = append(txns[i].SiafundOutputs, sfo)
 			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve siafund output rows: %w", err)
+			}
 			return nil
 		}()
 		if err != nil {
@@ -351,6 +372,9 @@ ORDER BY ts.transaction_order ASC`)
 				}
 
 				txns[i].FileContracts = append(txns[i].FileContracts, fce)
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve file contract rows: %w", err)
 			}
 			return nil
 		}()
@@ -402,7 +426,7 @@ ORDER BY ts.transaction_order ASC`)
 			contracts = append(contracts, fce)
 		}
 		if err := rows.Err(); err != nil {
-			return fmt.Errorf("failed to retrieve file contract rows: %w", err)
+			return nil, fmt.Errorf("failed to retrieve file contract rows: %w", err)
 		}
 		return contracts, nil
 	}
@@ -537,6 +561,9 @@ WHERE fc.id = ?`)
 
 				// Append the resolution to the transaction.
 				txns[i].FileContractResolutions = append(txns[i].FileContractResolutions, fcr)
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to retrieve file contract resolution rows: %w", err)
 			}
 			return nil
 		}()


### PR DESCRIPTION
Many helper functions like those used to add transaction fields or update balances are only called in one or two places.  Instead of littering the function's name throughout the error messages in the function, instead just use the name of the function in the error message at the callsite.  This is already done in some places, but inconsistently.

Example:
```
 func addMinerPayouts(tx *txn, bid types.BlockID, scos []types.SiacoinOutput) error {
        stmt, err := tx.Prepare(`INSERT INTO miner_payouts(block_id, block_order, output_id) VALUES (?, ?, (SELECT id FROM siacoin_elements WHERE output_id = ?));`)
        if err != nil {
-               return fmt.Errorf("addMinerPayouts: failed to prepare statement: %w", err)
+               return fmt.Errorf("failed to prepare statement: %w", err)
        }
        defer stmt.Close()
 
        for i := range scos {
                if _, err := stmt.Exec(encode(bid), i, encode(bid.MinerOutputID(i))); err != nil {
-                       return fmt.Errorf("addMinerPayouts: failed to execute statement: %w", err)
+                       return fmt.Errorf("failed to execute statement: %w", err)
                }
        }
```

... later in `ApplyIndex`

```
        } else if err := addMinerPayouts(ut.tx, state.Block.ID(), state.Block.MinerPayouts); err != nil {
-               return fmt.Errorf("ApplyIndex: failed to add miner payouts: %w", err)
+               return fmt.Errorf("failed to add miner payouts: addMinerPayouts: %w", err)
```