### PR TITLE
api: Add /metrics/difficulty

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -286,6 +286,12 @@ func (c *Client) BlockTimeMetrics() (resp explorer.BlockTimeMetrics, err error) 
 	return
 }
 
+// DifficultyMetrics returns various difficulty-related metrics.
+func (c *Client) DifficultyMetrics(start, end uint64) (resp explorer.DifficultyMetrics, err error) {
+	err = c.c.GET(context.Background(), fmt.Sprintf("/metrics/difficulty?start=%d&end=%d", start, end), &resp)
+	return
+}
+
 // Search returns what type of object an ID is.
 func (c *Client) Search(id string) (resp explorer.SearchType, err error) {
 	err = c.c.GET(context.Background(), fmt.Sprintf("/search/%s", id), &resp)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -90,6 +90,7 @@ type Store interface {
 	LastSuccessScan() (time.Time, error)
 	HostMetrics() (HostMetrics, error)
 	BlockTimeMetrics(blockTime time.Duration) (BlockTimeMetrics, error)
+	DifficultyMetrics(start, end, step uint64) (DifficultyMetrics, error)
 	Transactions(ids []types.TransactionID) ([]Transaction, error)
 	TransactionChainIndices(txid types.TransactionID, offset, limit uint64) ([]types.ChainIndex, error)
 	V2Transactions(ids []types.TransactionID) ([]V2Transaction, error)
@@ -323,6 +324,11 @@ func (e *Explorer) HostMetrics() (HostMetrics, error) {
 // BlockTimeMetrics returns the average block time during various intervals.
 func (e *Explorer) BlockTimeMetrics() (BlockTimeMetrics, error) {
 	return e.s.BlockTimeMetrics(e.cm.TipState().Network.BlockInterval)
+}
+
+// DifficultyMetrics returns various difficulty-related metrics.
+func (e *Explorer) DifficultyMetrics(start, end, step uint64) (DifficultyMetrics, error) {
+	return e.s.DifficultyMetrics(start, end, step)
 }
 
 // Transactions returns the transactions with the specified IDs.

--- a/explorer/types.go
+++ b/explorer/types.go
@@ -612,3 +612,10 @@ type BlockTimeMetrics struct {
 	Week  time.Duration
 	Month time.Duration
 }
+
+// DifficultyMetrics contains various difficulty-related metrics.
+type DifficultyMetrics struct {
+	BlocksPerStep uint64           `json:"blocksPerStep"`
+	Difficulties  []consensus.Work `json:"difficulties"`
+	BlockTimes    []time.Duration  `json:"blockTimes"`
+}


### PR DESCRIPTION
Adds a `/metrics/difficulty` endpoint:
```
GET /metrics/difficulty?start=0&end=500000

Response 200:
{
  "blocksPerStep": 3333,
  "difficulties":["115312521", "119515127", "110032522", ...],
  "blockTimes": [618247, 291533, 1100934, ... ]
}
```
(Block times are given in milliseconds.)

Given a range of block heights, we determine an appropriate `step` such that we return at most 150 data points. (Picked somewhat arbitrarily; we should try other values.) This should allow the frontend to present graphs that can be panned and zoomed without having to transfer the whole data set.

As a future enhancement, we could also include the minimum and maximum values for each data point, and add fainter lines for them on the graph; that way, we don't hide outliers, even at low granularity.