### PR TITLE
api: Add drift to /metrics/difficulty

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -392,11 +392,13 @@ func TestAPI(t *testing.T) {
 			}
 			difficulties := make([]consensus.Work, 2)
 			blockTimes := make([]time.Duration, 2)
+			drifts := make([]time.Duration, 2)
 			for i, height := range []uint64{1, 2} {
 				index, _ := cm.BestIndex(height)
 				cs, _ := cm.State(index.ID)
 				difficulties[i] = cs.Difficulty
 				blockTimes[i] = cs.PrevTimestamps[0].Sub(cs.PrevTimestamps[1])
+				drifts[i] = cs.PrevTimestamps[0].Sub(network.HardforkOak.GenesisTimestamp.Add(time.Duration(height) * network.BlockInterval))
 			}
 			testutil.Equal(t, "blocks per step", 1, resp.BlocksPerStep)
 			testutil.Equal(t, "difficulties", difficulties, resp.Difficulties)
@@ -409,6 +411,7 @@ func TestAPI(t *testing.T) {
 			}
 			difficulties := make([]consensus.Work, 2)
 			blockTimes := make([]time.Duration, 2)
+			drifts := make([]time.Duration, 2)
 			for i, height := range []uint64{0, 2} {
 				index, _ := cm.BestIndex(height)
 				cs, _ := cm.State(index.ID)
@@ -416,10 +419,12 @@ func TestAPI(t *testing.T) {
 				if i > 0 {
 					blockTimes[i] = cs.PrevTimestamps[0].Sub(cs.PrevTimestamps[2]) / 2
 				}
+				drifts[i] = cs.PrevTimestamps[0].Sub(network.HardforkOak.GenesisTimestamp.Add(time.Duration(height) * network.BlockInterval))
 			}
 			testutil.Equal(t, "blocks per step", 2, resp.BlocksPerStep)
 			testutil.Equal(t, "difficulties", difficulties, resp.Difficulties)
 			testutil.Equal(t, "block times", blockTimes, resp.BlockTimes)
+			testutil.Equal(t, "drifts", drifts, resp.Drifts)
 		}},
 		{"Block", func(t *testing.T) {
 			tip := cm.Tip()

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -90,7 +90,7 @@ type Store interface {
 	LastSuccessScan() (time.Time, error)
 	HostMetrics() (HostMetrics, error)
 	BlockTimeMetrics(blockTime time.Duration) (BlockTimeMetrics, error)
-	DifficultyMetrics(start, end, step uint64) (DifficultyMetrics, error)
+	DifficultyMetrics(start, end, step uint64, n *consensus.Network) (DifficultyMetrics, error)
 	Transactions(ids []types.TransactionID) ([]Transaction, error)
 	TransactionChainIndices(txid types.TransactionID, offset, limit uint64) ([]types.ChainIndex, error)
 	V2Transactions(ids []types.TransactionID) ([]V2Transaction, error)
@@ -343,7 +343,7 @@ func (e *Explorer) BlockTimeMetrics() (BlockTimeMetrics, error) {
 
 // DifficultyMetrics returns various difficulty-related metrics.
 func (e *Explorer) DifficultyMetrics(start, end, step uint64) (DifficultyMetrics, error) {
-	return e.s.DifficultyMetrics(start, end, step)
+	return e.s.DifficultyMetrics(start, end, step, e.cm.TipState().Network)
 }
 
 // Transactions returns the transactions with the specified IDs.

--- a/explorer/types.go
+++ b/explorer/types.go
@@ -618,6 +618,7 @@ type DifficultyMetrics struct {
 	BlocksPerStep uint64           `json:"blocksPerStep"`
 	Difficulties  []consensus.Work `json:"difficulties"`
 	BlockTimes    []time.Duration  `json:"blockTimes"`
+	Drifts        []time.Duration  `json:"drifts"`
 }
 
 // TopSiacoin pairs an address with its Siacoin balance

--- a/persist/sqlite/metrics_test.go
+++ b/persist/sqlite/metrics_test.go
@@ -472,7 +472,7 @@ func TestDifficultyMetrics(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := n.db.DifficultyMetrics(tt.start, tt.end, tt.step)
+			result, err := n.db.DifficultyMetrics(tt.start, tt.end, tt.step, n.tipState().Network)
 			if tt.err != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.err) {
 					t.Fatalf("Expected %v, got %v", tt.err, err)
@@ -500,6 +500,9 @@ func TestDifficultyMetrics(t *testing.T) {
 			if len(result.BlockTimes) == 0 {
 				t.Error("Expected some block time data but got none")
 			}
+			if len(result.Drifts) == 0 {
+				t.Error("Expected some drift data but got none")
+			}
 
 			// Check that block times are reasonable (between 1 second and 1 hour)
 			for i, blockTime := range result.BlockTimes {
@@ -509,6 +512,12 @@ func TestDifficultyMetrics(t *testing.T) {
 					}
 				} else if blockTime < time.Second || blockTime > time.Hour {
 					t.Errorf("BlockTime[%d] = %v, seems unreasonable", i, blockTime)
+				}
+			}
+			// Check that the drifts are reasonable (between -1 hour and +1 hour)
+			for i, drift := range result.Drifts {
+				if drift < -time.Hour || drift > time.Hour {
+					t.Errorf("Drift[%d] = %v, seems unreasonable", i, drift)
 				}
 			}
 		})


### PR DESCRIPTION
"Drift" is the difference between the expected block timestamp (i.e. `genesisTimestamp + height*blockInterval`) and the actual block timestamps. It is directly used in the difficulty adjustment algorithm; generally speaking, we want to see the drift hovering around 0.

This data will be a bit noisier than `BlockTimes` (since it's not an average), but that's ok. 