### PR TITLE
Fix NDF

### DIFF
--- a/persist/sqlite/scan_test.go
+++ b/persist/sqlite/scan_test.go
@@ -330,8 +330,8 @@ func TestScan(t *testing.T) {
 
 	cfg := config.Scanner{
 		NumThreads:          100,
-		ScanTimeout:         100 * time.Millisecond,
-		ScanFrequency:       100 * time.Millisecond,
+		ScanTimeout:         500 * time.Millisecond,
+		ScanFrequency:       25 * time.Millisecond,
 		ScanInterval:        3 * time.Hour,
 		MinLastAnnouncement: 90 * 24 * time.Hour,
 	}


### PR DESCRIPTION
Fix #281

Raise ScanTimeout in `TestScan`.  Tested multiple values with `go test -count=10` and this was the lowest I could get it to work 100% of the time.