### PR TITLE
update workflow permissions

### DIFF
--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -1,7 +1,7 @@
 name: Sync OpenAPI Versions
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:


### PR DESCRIPTION
`sync-openapi-version.yml` specifies `write` so we need to grant that in the calling repo as well. 