### PR TITLE
Cache host metrics

### DIFF
--- a/.changeset/cache_host_metrics.md
+++ b/.changeset/cache_host_metrics.md
@@ -1,0 +1,13 @@
+---
+default: patch
+---
+
+# Cache host metrics
+
+#323 by @chris124567
+
+We are getting spammed with log messages about HostMetrics taking 50-100ms.  This PR cache the results and invalidates when we get new host scans to avoid this problem.  There are alternatives to the approach here, but because we compute medians instead of means (see #175) they are generally a bit ugly.  We could also periodically store snapshots of the host metrics in the database and have HostMetrics simply retrieve the latest one.  I don't feel too strongly either way.
+
+```
+DEBUG   sqlite3.transaction.rows        slow next       {"id": "bee57ec1", "attempt": 1, "elapsed": "64.314065ms", "stack": "go.sia.tech/explored/persist/sqlite.(*rows).Next\n\tgo.sia.tech/explored/persist/sqlite/sql.go:57\ngo.sia.tech/explored/persist/sqlite.(*Store).HostMetrics.func3\n\tgo.sia.tech/explored/persist/sqlite/metrics.go:65\ngo.sia.tech/explored/persist/sqlite.doTransaction\n\tgo.sia.tech/explored/persist/sqlite/store.go:91\ngo.sia.tech/explored/persist/sqlite.(*Store).transaction\n\tgo.sia.tech/explored/persist/sqlite/store.go:37\ngo.sia.tech/explored/persist/sqlite.(*Store).HostMetrics\n\tgo.sia.tech/explored/persist/sqlite/metrics.go:55\ngo.sia.tech/explored/explorer.(*Explorer).HostMetrics\n\tgo.sia.tech/explored/explorer/explorer.go:337\ngo.sia.tech/explored/api.(*server).hostMetricsHandler\n\tgo.sia.tech/explored/api/server.go:296\ngo.sia.tech/jape.Mux.adaptor.func1\n\tgo.sia.tech/jape@v0.14.1/server.go:185\ngithub.com/julienschmidt/httprouter.(*Router).ServeHTTP\n\tgithub.com/julienschmidt/httprouter@v1.3.0/router.go:387\nmain.runRootCmd.func1\n\tgo.sia.tech/explored/cmd/explored/main.go:313\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2286\nnet/http.serverHandler.ServeHTTP\n\tnet/http/server.go:3311\nnet/http.(*conn).serve\n\tnet/http/server.go:2073"}
+```

--- a/.changeset/cache_host_metrics.md
+++ b/.changeset/cache_host_metrics.md
@@ -3,11 +3,3 @@ default: patch
 ---
 
 # Cache host metrics
-
-#323 by @chris124567
-
-We are getting spammed with log messages about HostMetrics taking 50-100ms.  This PR cache the results and invalidates when we get new host scans to avoid this problem.  There are alternatives to the approach here, but because we compute medians instead of means (see #175) they are generally a bit ugly.  We could also periodically store snapshots of the host metrics in the database and have HostMetrics simply retrieve the latest one.  I don't feel too strongly either way.
-
-```
-DEBUG   sqlite3.transaction.rows        slow next       {"id": "bee57ec1", "attempt": 1, "elapsed": "64.314065ms", "stack": "go.sia.tech/explored/persist/sqlite.(*rows).Next\n\tgo.sia.tech/explored/persist/sqlite/sql.go:57\ngo.sia.tech/explored/persist/sqlite.(*Store).HostMetrics.func3\n\tgo.sia.tech/explored/persist/sqlite/metrics.go:65\ngo.sia.tech/explored/persist/sqlite.doTransaction\n\tgo.sia.tech/explored/persist/sqlite/store.go:91\ngo.sia.tech/explored/persist/sqlite.(*Store).transaction\n\tgo.sia.tech/explored/persist/sqlite/store.go:37\ngo.sia.tech/explored/persist/sqlite.(*Store).HostMetrics\n\tgo.sia.tech/explored/persist/sqlite/metrics.go:55\ngo.sia.tech/explored/explorer.(*Explorer).HostMetrics\n\tgo.sia.tech/explored/explorer/explorer.go:337\ngo.sia.tech/explored/api.(*server).hostMetricsHandler\n\tgo.sia.tech/explored/api/server.go:296\ngo.sia.tech/jape.Mux.adaptor.func1\n\tgo.sia.tech/jape@v0.14.1/server.go:185\ngithub.com/julienschmidt/httprouter.(*Router).ServeHTTP\n\tgithub.com/julienschmidt/httprouter@v1.3.0/router.go:387\nmain.runRootCmd.func1\n\tgo.sia.tech/explored/cmd/explored/main.go:313\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2286\nnet/http.serverHandler.ServeHTTP\n\tnet/http/server.go:3311\nnet/http.(*conn).serve\n\tnet/http/server.go:2073"}
-```

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -134,6 +134,7 @@ type Explorer struct {
 
 	mu              sync.Mutex // protects the fields below
 	lastSuccessScan time.Time
+	hostMetrics     HostMetrics
 }
 
 func (e *Explorer) syncStore(index types.ChainIndex, batchSize int) error {
@@ -332,9 +333,32 @@ func (e *Explorer) Metrics(id types.BlockID) (Metrics, error) {
 	return e.s.Metrics(id)
 }
 
-// HostMetrics returns various metrics about currently available hosts.
+// HostMetrics returns various metrics about currently available hosts. The
+// underlying query is expensive because it computes medians over every host,
+// so the result is cached and only recomputed after we store host scan results
+// (see invalidateHostMetrics).
 func (e *Explorer) HostMetrics() (HostMetrics, error) {
-	return e.s.HostMetrics()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.hostMetrics != (HostMetrics{}) {
+		return e.hostMetrics, nil
+	}
+	metrics, err := e.s.HostMetrics()
+	if err != nil {
+		return HostMetrics{}, err
+	}
+	e.hostMetrics = metrics
+	return e.hostMetrics, nil
+}
+
+// invalidateHostMetrics clears the cached hostMetrics result so the next
+// caller of HostMetrics recomputes it. Called after host scans
+// are persisted.
+func (e *Explorer) invalidateHostMetrics() {
+	e.mu.Lock()
+	e.hostMetrics = HostMetrics{}
+	e.mu.Unlock()
 }
 
 // BlockTimeMetrics returns the average block time during various intervals.
@@ -640,6 +664,7 @@ func (e *Explorer) ScanHosts(ctx context.Context, pks ...types.PublicKey) ([]Hos
 	if err := e.s.AddHostScans(scans...); err != nil {
 		return nil, fmt.Errorf("failed to add host scans to DB: %w", err)
 	}
+	e.invalidateHostMetrics()
 	return scans, nil
 }
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -335,8 +335,7 @@ func (e *Explorer) Metrics(id types.BlockID) (Metrics, error) {
 
 // HostMetrics returns various metrics about currently available hosts. The
 // underlying query is expensive because it computes medians over every host,
-// so the result is cached and only recomputed after we store host scan results
-// (see invalidateHostMetrics).
+// so the result is cached and only recomputed after we store host scan results.
 func (e *Explorer) HostMetrics() (HostMetrics, error) {
 	e.mu.Lock()
 	if e.hostMetrics != nil {
@@ -352,7 +351,9 @@ func (e *Explorer) HostMetrics() (HostMetrics, error) {
 	}
 
 	e.mu.Lock()
-	e.hostMetrics = &metrics
+	if e.hostMetrics == nil {
+		e.hostMetrics = &metrics
+	}
 	e.mu.Unlock()
 
 	return metrics, nil

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -134,7 +134,7 @@ type Explorer struct {
 
 	mu              sync.Mutex // protects the fields below
 	lastSuccessScan time.Time
-	hostMetrics     HostMetrics
+	hostMetrics     *HostMetrics
 }
 
 func (e *Explorer) syncStore(index types.ChainIndex, batchSize int) error {
@@ -339,17 +339,23 @@ func (e *Explorer) Metrics(id types.BlockID) (Metrics, error) {
 // (see invalidateHostMetrics).
 func (e *Explorer) HostMetrics() (HostMetrics, error) {
 	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	if e.hostMetrics != (HostMetrics{}) {
-		return e.hostMetrics, nil
+	if e.hostMetrics != nil {
+		m := *e.hostMetrics
+		e.mu.Unlock()
+		return m, nil
 	}
+	e.mu.Unlock()
+
 	metrics, err := e.s.HostMetrics()
 	if err != nil {
 		return HostMetrics{}, err
 	}
-	e.hostMetrics = metrics
-	return e.hostMetrics, nil
+
+	e.mu.Lock()
+	e.hostMetrics = &metrics
+	e.mu.Unlock()
+
+	return metrics, nil
 }
 
 // invalidateHostMetrics clears the cached hostMetrics result so the next
@@ -357,7 +363,7 @@ func (e *Explorer) HostMetrics() (HostMetrics, error) {
 // are persisted.
 func (e *Explorer) invalidateHostMetrics() {
 	e.mu.Lock()
-	e.hostMetrics = HostMetrics{}
+	e.hostMetrics = nil
 	e.mu.Unlock()
 }
 

--- a/explorer/scan.go
+++ b/explorer/scan.go
@@ -271,5 +271,6 @@ func (e *Explorer) scanLoop() {
 			e.log.Info("failed to add host scans to DB:", zap.Error(err))
 			return
 		}
+		e.invalidateHostMetrics()
 	}
 }


### PR DESCRIPTION
We are getting spammed with log messages about HostMetrics taking 50-100ms.  This PR caches the results and invalidates when we get new host scans to avoid this problem.  There are alternatives to the approach here, but because we compute medians instead of means (see #175) they are generally a bit ugly.  We could also periodically store snapshots of the host metrics in the database and have HostMetrics simply retrieve the latest one.  I don't feel too strongly either way.

```
DEBUG   sqlite3.transaction.rows        slow next       {"id": "bee57ec1", "attempt": 1, "elapsed": "64.314065ms", "stack": "go.sia.tech/explored/persist/sqlite.(*rows).Next\n\tgo.sia.tech/explored/persist/sqlite/sql.go:57\ngo.sia.tech/explored/persist/sqlite.(*Store).HostMetrics.func3\n\tgo.sia.tech/explored/persist/sqlite/metrics.go:65\ngo.sia.tech/explored/persist/sqlite.doTransaction\n\tgo.sia.tech/explored/persist/sqlite/store.go:91\ngo.sia.tech/explored/persist/sqlite.(*Store).transaction\n\tgo.sia.tech/explored/persist/sqlite/store.go:37\ngo.sia.tech/explored/persist/sqlite.(*Store).HostMetrics\n\tgo.sia.tech/explored/persist/sqlite/metrics.go:55\ngo.sia.tech/explored/explorer.(*Explorer).HostMetrics\n\tgo.sia.tech/explored/explorer/explorer.go:337\ngo.sia.tech/explored/api.(*server).hostMetricsHandler\n\tgo.sia.tech/explored/api/server.go:296\ngo.sia.tech/jape.Mux.adaptor.func1\n\tgo.sia.tech/jape@v0.14.1/server.go:185\ngithub.com/julienschmidt/httprouter.(*Router).ServeHTTP\n\tgithub.com/julienschmidt/httprouter@v1.3.0/router.go:387\nmain.runRootCmd.func1\n\tgo.sia.tech/explored/cmd/explored/main.go:313\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2286\nnet/http.serverHandler.ServeHTTP\n\tnet/http/server.go:3311\nnet/http.(*conn).serve\n\tnet/http/server.go:2073"}
```