### PR TITLE
Cap exponential scan backoff

### DIFF
--- a/.changeset/cap_scan_backoff.md
+++ b/.changeset/cap_scan_backoff.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Cap exponential scan backoff
+
+Cap the exponential backoff for failed host scans at 3 days. Previously the backoff was unbounded, which meant a host with a high failure streak could overflow `time.Duration` and be permanently excluded from scanning.

--- a/explorer/scan.go
+++ b/explorer/scan.go
@@ -115,6 +115,11 @@ func scanBackoff(interval, maxBackoff time.Duration, streak uint64) time.Duratio
 		return 0
 	}
 
+	// floor the cap to interval so failures never schedule sooner than successes
+	if maxBackoff < interval {
+		maxBackoff = interval
+	}
+
 	if streak >= 62 {
 		return maxBackoff
 	}

--- a/explorer/scan.go
+++ b/explorer/scan.go
@@ -3,7 +3,6 @@ package explorer
 import (
 	"context"
 	"fmt"
-	"math"
 	"net"
 	"sync"
 	"time"
@@ -17,6 +16,9 @@ import (
 	rhpv3 "go.sia.tech/explored/internal/rhp/v3"
 	"go.uber.org/zap"
 )
+
+// maxScanBackoff is the maximum duration between scan attempts
+const maxScanBackoff = 3 * 24 * time.Hour
 
 func isSynced(b Block) bool {
 	return time.Since(b.Timestamp) <= 3*time.Hour
@@ -106,6 +108,23 @@ func rhpv3PriceTable(ctx context.Context, publicKey types.PublicKey, netAddress 
 		return crhpv3.HostPriceTable{}, fmt.Errorf("failed to scan price table: %w", err)
 	}
 	return table, nil
+}
+
+func scanBackoff(interval, maxBackoff time.Duration, streak uint64) time.Duration {
+	if interval <= 0 || maxBackoff <= 0 {
+		return 0
+	}
+
+	if streak >= 62 {
+		return maxBackoff
+	}
+
+	shift := streak + 1
+	factor := time.Duration(1) << shift
+	if interval > maxBackoff/factor {
+		return maxBackoff
+	}
+	return interval * factor
 }
 
 func (e *Explorer) scanV1Host(ctx context.Context, host UnscannedHost) (HostScan, error) {
@@ -254,7 +273,7 @@ func (e *Explorer) scanLoop() {
 							return &str
 						}(),
 						Timestamp: now,
-						NextScan:  now.Add(e.scanCfg.ScanInterval * time.Duration(math.Pow(2, float64(host.FailedInteractionsStreak)+1))),
+						NextScan:  now.Add(scanBackoff(e.scanCfg.ScanInterval, maxScanBackoff, host.FailedInteractionsStreak)),
 					}
 					return
 				} else {

--- a/explorer/scan_test.go
+++ b/explorer/scan_test.go
@@ -1,0 +1,47 @@
+package explorer
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestScanBackoff(t *testing.T) {
+	tests := []struct {
+		name       string
+		interval   time.Duration
+		maxBackoff time.Duration
+		streak     uint64
+		want       time.Duration
+	}{
+		{
+			name:       "exponential backoff",
+			interval:   time.Minute,
+			maxBackoff: time.Hour,
+			streak:     1,
+			want:       4 * time.Minute,
+		},
+		{
+			name:       "capped at max backoff",
+			interval:   time.Minute,
+			maxBackoff: 10 * time.Minute,
+			streak:     4,
+			want:       10 * time.Minute,
+		},
+		{
+			name:       "huge streak caps instead of overflowing",
+			interval:   time.Minute,
+			maxBackoff: time.Hour,
+			streak:     math.MaxUint64,
+			want:       time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scanBackoff(tt.interval, tt.maxBackoff, tt.streak); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/explorer/scan_test.go
+++ b/explorer/scan_test.go
@@ -35,6 +35,13 @@ func TestScanBackoff(t *testing.T) {
 			streak:     math.MaxUint64,
 			want:       time.Hour,
 		},
+		{
+			name:       "interval larger than max backoff floors the cap",
+			interval:   7 * 24 * time.Hour,
+			maxBackoff: 3 * 24 * time.Hour,
+			streak:     5,
+			want:       7 * 24 * time.Hour,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes a potential overflow, I realised later that it's highly unlikely to be an issue in practice but better safe than sorry I guess